### PR TITLE
fix: 章节文件默认写入卷目录而非正文根目录

### DIFF
--- a/webnovel-writer/agents/continuity-checker.md
+++ b/webnovel-writer/agents/continuity-checker.md
@@ -27,7 +27,7 @@ model: inherit
   "project_root": "{PROJECT_ROOT}",
   "storage_path": ".webnovel/",
   "state_file": ".webnovel/state.json",
-  "chapter_file": "正文/第{NNNN}章-{title_safe}.md"
+  "chapter_file": "正文/第{N}卷/第{NNN}章-{title_safe}.md"
 }
 ```
 

--- a/webnovel-writer/agents/pacing-checker.md
+++ b/webnovel-writer/agents/pacing-checker.md
@@ -27,7 +27,7 @@ model: inherit
   "project_root": "{PROJECT_ROOT}",
   "storage_path": ".webnovel/",
   "state_file": ".webnovel/state.json",
-  "chapter_file": "正文/第{NNNN}章-{title_safe}.md"
+  "chapter_file": "正文/第{N}卷/第{NNN}章-{title_safe}.md"
 }
 ```
 

--- a/webnovel-writer/scripts/chapter_paths.py
+++ b/webnovel-writer/scripts/chapter_paths.py
@@ -135,7 +135,7 @@ def find_chapter_file(project_root: Path, chapter_num: int) -> Optional[Path]:
     return None
 
 
-def default_chapter_draft_path(project_root: Path, chapter_num: int, *, use_volume_layout: bool = False) -> Path:
+def default_chapter_draft_path(project_root: Path, chapter_num: int, *, use_volume_layout: bool = True) -> Path:
     """
     Preferred draft path when creating a new chapter file.
 

--- a/webnovel-writer/scripts/data_modules/rag_adapter.py
+++ b/webnovel-writer/scripts/data_modules/rag_adapter.py
@@ -1407,6 +1407,7 @@ def main():
     index_parser.add_argument("--chapter", type=int, required=True)
     index_parser.add_argument("--scenes", required=True, help="JSON 格式的场景列表")
     index_parser.add_argument("--summary", required=False, help="章节摘要文本")
+    index_parser.add_argument("--chapter-file", required=False, help="实际章节文件路径")
 
     # 搜索
     search_parser = subparsers.add_parser("search")
@@ -1509,7 +1510,7 @@ def main():
                     "chunk_type": "scene",
                     "parent_chunk_id": parent_chunk_id,
                     "chunk_id": chunk_id,
-                    "source_file": f"正文/第{args.chapter:04d}章.md#scene_{int(scene_index)}",
+                    "source_file": f"{args.chapter_file}#scene_{int(scene_index)}" if getattr(args, "chapter_file", None) else f"正文/第{args.chapter:04d}章.md#scene_{int(scene_index)}",
                 }
             )
 

--- a/webnovel-writer/scripts/data_modules/tests/test_chapter_paths.py
+++ b/webnovel-writer/scripts/data_modules/tests/test_chapter_paths.py
@@ -24,7 +24,8 @@ def test_default_chapter_draft_path_uses_outline_heading_title(tmp_path):
 
     draft_path = module.default_chapter_draft_path(tmp_path, 1)
 
-    assert draft_path.name == "第0001章-测试标题.md"
+    assert draft_path.parent.name == "第1卷"
+    assert draft_path.name == "第001章-测试标题.md"
 
 
 def test_default_chapter_draft_path_falls_back_to_split_outline_filename(tmp_path):
@@ -36,7 +37,8 @@ def test_default_chapter_draft_path_falls_back_to_split_outline_filename(tmp_pat
 
     draft_path = module.default_chapter_draft_path(tmp_path, 2)
 
-    assert draft_path.name == "第0002章-标题_文件.md"
+    assert draft_path.parent.name == "第1卷"
+    assert draft_path.name == "第002章-标题_文件.md"
 
 
 def test_find_chapter_file_supports_titled_flat_filename(tmp_path):

--- a/webnovel-writer/skills/webnovel-write/SKILL.md
+++ b/webnovel-writer/skills/webnovel-write/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Read Write Edit Grep Bash Task
 
 ## 目标
 
-- 以稳定流程产出可发布章节：优先使用 `正文/第{NNNN}章-{title_safe}.md`，无标题时回退 `正文/第{NNNN}章.md`。
+- 以稳定流程产出可发布章节：优先使用 `正文/第{N}卷/第{NNN}章-{title_safe}.md`，无标题时回退 `正文/第{N}卷/第{NNN}章.md`。
 - 默认章节字数目标：2000-2500（用户或大纲明确覆盖时从其约定）。
 - 保证审查、润色、数据回写完整闭环，避免“写完即丢上下文”。
 - 输出直接可被后续章节消费的结构化数据：`review_metrics`、`summaries`、`chapter_meta`。
@@ -28,7 +28,7 @@ allowed-tools: Read Write Edit Grep Bash Task
 - `/webnovel-write --minimal`：Step 1 → 2A → 3（仅3个基础审查）→ 4 → 5 → 6
 
 最小产物（所有模式）：
-- `正文/第{NNNN}章-{title_safe}.md` 或 `正文/第{NNNN}章.md`
+- `正文/第{N}卷/第{NNN}章-{title_safe}.md` 或 `正文/第{N}卷/第{NNN}章.md`
 - `index.db.review_metrics` 新纪录（含 `overall_score`）
 - `.webnovel/summaries/ch{NNNN}.md`
 - `.webnovel/state.json` 的进度与 `chapter_meta` 更新
@@ -177,7 +177,7 @@ cat "${SKILL_ROOT}/../../references/shared/core-constraints.md"
 ```
 
 硬要求：
-- 只输出纯正文到章节正文文件；若详细大纲已有章节名，优先使用 `正文/第{chapter_padded}章-{title_safe}.md`，否则回退为 `正文/第{chapter_padded}章.md`。
+- 只输出纯正文到章节正文文件；路径由 `chapter_paths.py` 的 `default_chapter_draft_path()` 决定，默认卷布局：`正文/第{N}卷/第{NNN}章-{title_safe}.md`，无标题时回退为 `正文/第{N}卷/第{NNN}章.md`。
 - 默认按 2000-2500 字执行；若大纲为关键战斗章/高潮章/卷末章或用户明确指定，则按大纲/用户优先。
 - 禁止占位符正文（如 `[TODO]`、`[待补充]`）。
 - 保留承接关系：若上章有明确钩子，本章必须回应（可部分兑现）。
@@ -278,7 +278,7 @@ cat "${SKILL_ROOT}/references/writing/typesetting.md"
 
 使用 Task 调用 `data-agent`，参数：
 - `chapter`
-- `chapter_file` 必须传入实际章节文件路径；若详细大纲已有章节名，优先传 `正文/第{chapter_padded}章-{title_safe}.md`，否则传 `正文/第{chapter_padded}章.md`
+- `chapter_file` 必须传入实际章节文件路径；路径由 `chapter_paths.py` 决定，默认卷布局：`正文/第{N}卷/第{NNN}章-{title_safe}.md`
 - `review_score=Step 3 overall_score`
 - `project_root`
 - `storage_path=.webnovel/`
@@ -339,7 +339,7 @@ git -c i18n.commitEncoding=UTF-8 commit -m "第{chapter_num}章: {title}"
 
 未满足以下条件前，不得结束流程：
 
-1. 章节正文文件存在且非空：`正文/第{chapter_padded}章-{title_safe}.md` 或 `正文/第{chapter_padded}章.md`
+1. 章节正文文件存在且非空：`正文/第{N}卷/第{NNN}章-{title_safe}.md` 或 `正文/第{N}卷/第{NNN}章.md`
 2. Step 3 已产出 `overall_score` 且 `review_metrics` 成功落库
 3. Step 4 已处理全部 `critical`，`high` 未修项有 deviation 记录
 4. Step 4 的 `anti_ai_force_check=pass`（基于全文检查；fail 时不得进入 Step 5）
@@ -352,7 +352,7 @@ git -c i18n.commitEncoding=UTF-8 commit -m "第{chapter_num}章: {title}"
 
 ```bash
 test -f "${PROJECT_ROOT}/.webnovel/state.json"
-test -f "${PROJECT_ROOT}/正文/第${chapter_padded}章.md"
+test -f "${PROJECT_ROOT}/正文/第${volume_num}卷/第${chapter_padded_3}章.md" || test -f "${PROJECT_ROOT}/正文/第${chapter_padded}章.md"
 test -f "${PROJECT_ROOT}/.webnovel/summaries/ch${chapter_padded}.md"
 python -X utf8 "${SCRIPTS_DIR}/webnovel.py" --project-root "${PROJECT_ROOT}" index get-recent-review-metrics --limit 1
 tail -n 1 "${PROJECT_ROOT}/.webnovel/observability/data_agent_timing.jsonl" || true

--- a/webnovel-writer/skills/webnovel-write/references/polish-guide.md
+++ b/webnovel-writer/skills/webnovel-write/references/polish-guide.md
@@ -23,7 +23,7 @@ purpose: 章节生成后的润色阶段加载，基于审查报告修复问题 +
 
 ```json
 {
-  "chapter_file": "正文/第0123章-章节标题.md",
+  "chapter_file": "正文/第3卷/第123章-章节标题.md",
   "overall_score": 82,
   "issues": [
     {"agent": "consistency-checker", "type": "POWER_CONFLICT", "severity": "critical", "location": "第6段", "suggestion": "境界越权"},
@@ -33,7 +33,7 @@ purpose: 章节生成后的润色阶段加载，基于审查报告修复问题 +
 }
 ```
 
-`chapter_file` 必须是当前章节的实际文件路径；若项目尚未迁移到带标题文件名，也可传 `正文/第0123章.md`。
+`chapter_file` 必须是当前章节的实际文件路径；旧项目平坦布局也可传 `正文/第0123章.md`。
 
 ## 2. 执行顺序（必须按序）
 


### PR DESCRIPTION
chapter_paths.py 的 default_chapter_draft_path 默认值从平坦布局改为卷布局， 与 init_project.py 创建的 正文/第1卷/ 目录结构保持一致。
同步更新 SKILL.md、agent 文档、polish-guide、rag_adapter 及测试用例。