### PR TITLE
fix: 初始化项目时使用平坦正文目录，不再预创建卷子目录

### DIFF
--- a/webnovel-writer/scripts/init_project.py
+++ b/webnovel-writer/scripts/init_project.py
@@ -278,7 +278,7 @@ def init_project(
         "设定集/物品库",
         "设定集/其他设定",
         "大纲",
-        "正文/第1卷",
+        "正文",
         "审查报告",
     ]
     for dir_path in directories:


### PR DESCRIPTION
初始化项目时使用平坦正文目录，不再预创建卷子目录

作者建议是对的，上个修改，太粗旷了，忘记向后兼容了。