### PR TITLE
feat(dashboard): 新增 RAG / Rerank 环境状态检测面板

### DIFF
--- a/webnovel-writer/dashboard/app.py
+++ b/webnovel-writer/dashboard/app.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import os
 import sqlite3
+import time
 from contextlib import asynccontextmanager, closing
 from pathlib import Path
 from typing import Optional
@@ -130,6 +131,115 @@ def create_app(project_root: str | Path | None = None) -> FastAPI:
                 "key_configured": bool(rerank_key),
                 "base_url": rerank_url,
                 "model": rerank_model,
+            },
+            "vector_db": {
+                "exists": vector_db_exists,
+                "size_kb": round(vectors_db.stat().st_size / 1024, 1) if vector_db_exists else 0,
+            },
+            "rag_mode": rag_mode,
+        }
+
+    @app.get("/api/env-status/probe")
+    async def env_status_probe():
+        """主动探测 Embedding / Rerank 服务连通性（发起真实 HTTP 请求，超时 8s）。"""
+        import aiohttp
+
+        # 复用 env_status 的配置读取逻辑
+        project_env: dict[str, str] = {}
+        env_file = _get_project_root() / ".env"
+        if env_file.is_file():
+            for raw in env_file.read_text(encoding="utf-8").splitlines():
+                line = raw.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                k, _, v = line.partition("=")
+                k = k.strip()
+                v = v.strip().strip('"').strip("'")
+                if k:
+                    project_env[k] = v
+
+        def _get(name: str, default: str = "") -> str:
+            return os.getenv(name) or project_env.get(name) or default
+
+        embed_key   = _get("EMBED_API_KEY")
+        rerank_key  = _get("RERANK_API_KEY")
+        embed_url   = _get("EMBED_BASE_URL", "https://api-inference.modelscope.cn/v1")
+        rerank_url  = _get("RERANK_BASE_URL", "https://api.jina.ai/v1")
+        embed_model = _get("EMBED_MODEL", "Qwen/Qwen3-Embedding-8B")
+        rerank_model = _get("RERANK_MODEL", "jina-reranker-v3")
+
+        TIMEOUT = aiohttp.ClientTimeout(total=8)
+
+        async def _probe_embed() -> dict:
+            if not embed_key:
+                return {"ok": False, "latency_ms": None, "error": "未配置 EMBED_API_KEY"}
+            url = embed_url.rstrip("/") + "/embeddings"
+            headers = {"Authorization": f"Bearer {embed_key}", "Content-Type": "application/json"}
+            payload = {"model": embed_model, "input": ["test"]}
+            t0 = time.monotonic()
+            try:
+                async with aiohttp.ClientSession(timeout=TIMEOUT) as s:
+                    async with s.post(url, json=payload, headers=headers) as r:
+                        latency = round((time.monotonic() - t0) * 1000)
+                        if r.status == 200:
+                            return {"ok": True, "latency_ms": latency, "error": None}
+                        text = (await r.text())[:120]
+                        return {"ok": False, "latency_ms": latency, "error": f"HTTP {r.status}: {text}"}
+            except asyncio.TimeoutError:
+                return {"ok": False, "latency_ms": None, "error": "请求超时（>8s）"}
+            except Exception as e:
+                return {"ok": False, "latency_ms": None, "error": str(e)[:120]}
+
+        async def _probe_rerank() -> dict:
+            if not rerank_key:
+                return {"ok": False, "latency_ms": None, "error": "未配置 RERANK_API_KEY"}
+            url = rerank_url.rstrip("/") + "/rerank"
+            headers = {"Authorization": f"Bearer {rerank_key}", "Content-Type": "application/json"}
+            payload = {"model": rerank_model, "query": "test", "documents": ["a", "b"]}
+            t0 = time.monotonic()
+            try:
+                async with aiohttp.ClientSession(timeout=TIMEOUT) as s:
+                    async with s.post(url, json=payload, headers=headers) as r:
+                        latency = round((time.monotonic() - t0) * 1000)
+                        if r.status == 200:
+                            return {"ok": True, "latency_ms": latency, "error": None}
+                        text = (await r.text())[:120]
+                        return {"ok": False, "latency_ms": latency, "error": f"HTTP {r.status}: {text}"}
+            except asyncio.TimeoutError:
+                return {"ok": False, "latency_ms": None, "error": "请求超时（>8s）"}
+            except Exception as e:
+                return {"ok": False, "latency_ms": None, "error": str(e)[:120]}
+
+        embed_result, rerank_result = await asyncio.gather(
+            _probe_embed(), _probe_rerank()
+        )
+
+        vectors_db = _webnovel_dir() / "vectors.db"
+        vector_db_exists = vectors_db.is_file() and vectors_db.stat().st_size > 0
+
+        if not embed_key:
+            rag_mode = "disabled"
+        elif not vector_db_exists:
+            rag_mode = "bm25_fallback"
+        elif not embed_result["ok"]:
+            rag_mode = "bm25_fallback"
+        elif not rerank_key or not rerank_result["ok"]:
+            rag_mode = "vector_only"
+        else:
+            rag_mode = "vector+rerank"
+
+        return {
+            "embed": {
+                "key_configured": bool(embed_key),
+                "base_url": embed_url,
+                "model": embed_model,
+                **embed_result,
+            },
+            "rerank": {
+                "key_configured": bool(rerank_key),
+                "base_url": rerank_url,
+                "model": rerank_model,
+                **rerank_result,
             },
             "vector_db": {
                 "exists": vector_db_exists,

--- a/webnovel-writer/dashboard/app.py
+++ b/webnovel-writer/dashboard/app.py
@@ -6,6 +6,7 @@ Webnovel Dashboard - FastAPI 主应用
 
 import asyncio
 import json
+import os
 import sqlite3
 from contextlib import asynccontextmanager, closing
 from pathlib import Path
@@ -78,6 +79,64 @@ def create_app(project_root: str | Path | None = None) -> FastAPI:
         if not state_path.is_file():
             raise HTTPException(404, "state.json 不存在")
         return json.loads(state_path.read_text(encoding="utf-8"))
+
+    @app.get("/api/env-status")
+    def env_status():
+        """检测 RAG / Rerank 环境配置状态（仅读取本地配置与文件，不发起网络请求）。"""
+        # 读取项目级 .env（best-effort，不覆盖进程已有环境变量）
+        project_env: dict[str, str] = {}
+        env_file = _get_project_root() / ".env"
+        if env_file.is_file():
+            for raw in env_file.read_text(encoding="utf-8").splitlines():
+                line = raw.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                k, _, v = line.partition("=")
+                k = k.strip()
+                v = v.strip().strip('"').strip("'")
+                if k:
+                    project_env[k] = v
+
+        def _get(name: str, default: str = "") -> str:
+            return os.getenv(name) or project_env.get(name) or default
+
+        embed_key = _get("EMBED_API_KEY")
+        rerank_key = _get("RERANK_API_KEY")
+        embed_url = _get("EMBED_BASE_URL", "https://api-inference.modelscope.cn/v1")
+        rerank_url = _get("RERANK_BASE_URL", "https://api.jina.ai/v1")
+        embed_model = _get("EMBED_MODEL", "Qwen/Qwen3-Embedding-8B")
+        rerank_model = _get("RERANK_MODEL", "jina-reranker-v3")
+
+        vectors_db = _webnovel_dir() / "vectors.db"
+        vector_db_exists = vectors_db.is_file() and vectors_db.stat().st_size > 0
+
+        # 推导 RAG 运行模式（对应 rag_adapter.py 三级降级逻辑）
+        if not embed_key:
+            rag_mode = "disabled"
+        elif not vector_db_exists:
+            rag_mode = "bm25_fallback"
+        elif not rerank_key:
+            rag_mode = "vector_only"
+        else:
+            rag_mode = "vector+rerank"
+
+        return {
+            "embed": {
+                "key_configured": bool(embed_key),
+                "base_url": embed_url,
+                "model": embed_model,
+            },
+            "rerank": {
+                "key_configured": bool(rerank_key),
+                "base_url": rerank_url,
+                "model": rerank_model,
+            },
+            "vector_db": {
+                "exists": vector_db_exists,
+                "size_kb": round(vectors_db.stat().st_size / 1024, 1) if vector_db_exists else 0,
+            },
+            "rag_mode": rag_mode,
+        }
 
     # ===========================================================
     # API：实体数据库（index.db 只读查询）

--- a/webnovel-writer/dashboard/frontend/src/App.jsx
+++ b/webnovel-writer/dashboard/frontend/src/App.jsx
@@ -245,36 +245,66 @@ const RAG_MODE_BADGE = {
 }
 
 function RagStatusCard() {
-    const [status, setStatus] = useState(null)
-    const [error, setError] = useState(false)
+    const [config, setConfig] = useState(null)    // 配置状态（快速加载）
+    const [probe, setProbe] = useState(null)       // 探测结果（点按钮后）
+    const [probing, setProbing] = useState(false)  // 探测进行中
 
     useEffect(() => {
         fetchJSON('/api/env-status')
-            .then(d => { setStatus(d); setError(false) })
-            .catch(() => setError(true))
+            .then(setConfig)
+            .catch(() => {})
     }, [])
 
-    if (error) return null
-    if (!status) return null
+    const runProbe = () => {
+        setProbing(true)
+        setProbe(null)
+        fetchJSON('/api/env-status/probe')
+            .then(d => { setProbe(d); setProbing(false) })
+            .catch(() => setProbing(false))
+    }
+
+    if (!config) return null
+
+    // 探测结果优先，否则用配置状态
+    const status = probe || config
+    const isProbeResult = !!probe
 
     const rows = [
         {
             label: 'Embedding',
-            ok: status.embed.key_configured,
-            detail: status.embed.key_configured ? status.embed.model : '未配置 EMBED_API_KEY',
+            // 探测结果看 ok 字段；配置状态看 key_configured
+            ok: isProbeResult ? status.embed.ok : status.embed.key_configured,
+            detail: (() => {
+                if (isProbeResult) {
+                    if (status.embed.ok) return `${status.embed.model} · ${status.embed.latency_ms}ms`
+                    return status.embed.error || '连接失败'
+                }
+                return status.embed.key_configured ? status.embed.model : '未配置 EMBED_API_KEY'
+            })(),
             hint: status.embed.base_url,
+            warn: isProbeResult && !status.embed.ok && status.embed.key_configured,
         },
         {
             label: 'Rerank',
-            ok: status.rerank.key_configured,
-            detail: status.rerank.key_configured ? status.rerank.model : '未配置 RERANK_API_KEY',
+            ok: isProbeResult ? status.rerank.ok : status.rerank.key_configured,
+            detail: (() => {
+                if (isProbeResult) {
+                    if (status.rerank.ok) return `${status.rerank.model} · ${status.rerank.latency_ms}ms`
+                    return status.rerank.error || '连接失败'
+                }
+                return status.rerank.key_configured ? status.rerank.model : '未配置 RERANK_API_KEY'
+            })(),
             hint: status.rerank.base_url,
+            warn: isProbeResult && !status.rerank.ok && status.rerank.key_configured,
         },
         {
             label: '向量库',
             ok: status.vector_db.exists,
-            detail: status.vector_db.exists ? `vectors.db · ${status.vector_db.size_kb} KB` : '未建立 (vectors.db)',
+            detail: status.vector_db.exists
+                ? `vectors.db · ${status.vector_db.size_kb} KB`
+                : '未建立 (vectors.db)',
             hint: null,
+            warn: false,
         },
     ]
 
@@ -282,20 +312,36 @@ function RagStatusCard() {
         <div className="card dashboard-section-card">
             <div className="card-header">
                 <span className="card-title">🔍 RAG 环境状态</span>
-                <span className={`card-badge ${RAG_MODE_BADGE[status.rag_mode] || 'badge-amber'}`}>
-                    {RAG_MODE_LABEL[status.rag_mode] || status.rag_mode}
-                </span>
+                <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+                    {isProbeResult && (
+                        <span className={`card-badge ${RAG_MODE_BADGE[status.rag_mode] || 'badge-amber'}`}>
+                            {RAG_MODE_LABEL[status.rag_mode] || status.rag_mode}
+                        </span>
+                    )}
+                    <button
+                        className={`rag-probe-btn ${probing ? 'probing' : ''}`}
+                        onClick={runProbe}
+                        disabled={probing}
+                    >
+                        {probing ? '检测中…' : '检测连通性'}
+                    </button>
+                </div>
             </div>
             <div className="rag-status-grid">
                 {rows.map(row => (
-                    <div key={row.label} className="rag-status-row">
-                        <span className="rag-status-icon">{row.ok ? '✅' : '❌'}</span>
+                    <div key={row.label} className={`rag-status-row${row.warn ? ' warn' : ''}`}>
+                        <span className="rag-status-icon">
+                            {probing ? '⏳' : row.ok ? '✅' : '❌'}
+                        </span>
                         <span className="rag-status-label">{row.label}</span>
                         <span className="rag-status-detail">{row.detail}</span>
                         {row.hint && <span className="rag-status-url">{row.hint}</span>}
                     </div>
                 ))}
             </div>
+            {!isProbeResult && (
+                <p className="rag-status-hint">以上为本地配置读取结果，点击"检测连通性"进行真实服务探测</p>
+            )}
         </div>
     )
 }

--- a/webnovel-writer/dashboard/frontend/src/App.jsx
+++ b/webnovel-writer/dashboard/frontend/src/App.jsx
@@ -221,10 +221,84 @@ function DashboardPage({ data }) {
             ) : null}
 
             <MergedDataView />
+            <RagStatusCard />
         </>
     )
 }
 
+
+// ====================================================================
+// RAG 环境状态卡片
+// ====================================================================
+
+const RAG_MODE_LABEL = {
+    'vector+rerank': '向量检索 + Rerank',
+    'vector_only':   '向量检索（无 Rerank）',
+    'bm25_fallback': 'BM25 降级',
+    'disabled':      '未启用',
+}
+const RAG_MODE_BADGE = {
+    'vector+rerank': 'badge-green',
+    'vector_only':   'badge-blue',
+    'bm25_fallback': 'badge-amber',
+    'disabled':      'badge-red',
+}
+
+function RagStatusCard() {
+    const [status, setStatus] = useState(null)
+    const [error, setError] = useState(false)
+
+    useEffect(() => {
+        fetchJSON('/api/env-status')
+            .then(d => { setStatus(d); setError(false) })
+            .catch(() => setError(true))
+    }, [])
+
+    if (error) return null
+    if (!status) return null
+
+    const rows = [
+        {
+            label: 'Embedding',
+            ok: status.embed.key_configured,
+            detail: status.embed.key_configured ? status.embed.model : '未配置 EMBED_API_KEY',
+            hint: status.embed.base_url,
+        },
+        {
+            label: 'Rerank',
+            ok: status.rerank.key_configured,
+            detail: status.rerank.key_configured ? status.rerank.model : '未配置 RERANK_API_KEY',
+            hint: status.rerank.base_url,
+        },
+        {
+            label: '向量库',
+            ok: status.vector_db.exists,
+            detail: status.vector_db.exists ? `vectors.db · ${status.vector_db.size_kb} KB` : '未建立 (vectors.db)',
+            hint: null,
+        },
+    ]
+
+    return (
+        <div className="card dashboard-section-card">
+            <div className="card-header">
+                <span className="card-title">🔍 RAG 环境状态</span>
+                <span className={`card-badge ${RAG_MODE_BADGE[status.rag_mode] || 'badge-amber'}`}>
+                    {RAG_MODE_LABEL[status.rag_mode] || status.rag_mode}
+                </span>
+            </div>
+            <div className="rag-status-grid">
+                {rows.map(row => (
+                    <div key={row.label} className="rag-status-row">
+                        <span className="rag-status-icon">{row.ok ? '✅' : '❌'}</span>
+                        <span className="rag-status-label">{row.label}</span>
+                        <span className="rag-status-detail">{row.detail}</span>
+                        {row.hint && <span className="rag-status-url">{row.hint}</span>}
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+}
 
 // ====================================================================
 // 页面 2：设定词典

--- a/webnovel-writer/dashboard/frontend/src/index.css
+++ b/webnovel-writer/dashboard/frontend/src/index.css
@@ -206,6 +206,43 @@ body {
 .badge-purple { background: #ece3ff; color: #4a2ea8; }
 .badge-cyan { background: #dcfafe; color: #155e75; }
 
+/* RAG 环境状态卡片 */
+.rag-status-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0.25rem 0;
+}
+.rag-status-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: 6px;
+  background: var(--bg-card-2);
+}
+.rag-status-icon { font-size: 1rem; flex-shrink: 0; }
+.rag-status-label {
+  font-weight: 600;
+  font-size: 0.84rem;
+  color: var(--text-main);
+  min-width: 72px;
+}
+.rag-status-detail {
+  font-size: 0.82rem;
+  color: var(--text-sub);
+  flex: 1;
+}
+.rag-status-url {
+  font-size: 0.74rem;
+  color: var(--text-mute);
+  font-family: monospace;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .dashboard-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));

--- a/webnovel-writer/dashboard/frontend/src/index.css
+++ b/webnovel-writer/dashboard/frontend/src/index.css
@@ -221,6 +221,9 @@ body {
   border-radius: 6px;
   background: var(--bg-card-2);
 }
+.rag-status-row.warn {
+  background: #fff1cd;
+}
 .rag-status-icon { font-size: 1rem; flex-shrink: 0; }
 .rag-status-label {
   font-weight: 600;
@@ -241,6 +244,32 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.rag-status-hint {
+  font-size: 0.76rem;
+  color: var(--text-mute);
+  margin: 0.5rem 0.25rem 0;
+}
+.rag-probe-btn {
+  font-size: 0.78rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 5px;
+  border: 1.5px solid var(--border-soft);
+  background: var(--bg-card);
+  color: var(--text-sub);
+  cursor: pointer;
+  font-weight: 600;
+  transition: background 0.15s, color 0.15s;
+}
+.rag-probe-btn:hover:not(:disabled) {
+  background: var(--accent-blue);
+  color: #fff;
+  border-color: var(--accent-blue);
+}
+.rag-probe-btn.probing,
+.rag-probe-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
 .dashboard-grid {


### PR DESCRIPTION
## 背景
RAG 模块存在三级静默降级（无 key → BM25、API 失败 → BM25、无向量库 → 跳过），
但用户在 Dashboard 无法判断 RAG 是否真正在工作。

## 改动内容
### 后端
- 新增 `GET /api/env-status`：读取本地配置（env var + 项目 `.env` 文件），
  检查 `vectors.db` 是否存在，推导当前 `rag_mode`（快速，不发网络请求）
- 新增 `GET /api/env-status/probe`：主动 ping Embedding / Rerank 服务
  （aiohttp，8s 超时），返回实际连通性、延迟和错误信息
### 前端
- Dashboard 首页新增「🔍 RAG 环境状态」卡片
- 页面加载时显示配置读取结果（立即响应）
- 点击「检测连通性」按钮后调用 `/probe`，展示真实延迟和错误详情
- key 已配置但连接失败时，对应行高亮为警告色

## 效果
| 状态 | 显示 |
|---|---|
| 全部正常 | ✅ 三行绿色 + 绿色 badge "向量检索 + Rerank" |
| Embedding 连不上 | ❌ 红色 + 具体错误信息 + badge 变橙 "BM25 降级" |
| 未配置 key | ❌ 提示未配置字段名 |