### PR TITLE
fix: 空字符串导致 Gemini embedding API 400 错误 (#49)

### DIFF
--- a/webnovel-writer/scripts/data_modules/api_client.py
+++ b/webnovel-writer/scripts/data_modules/api_client.py
@@ -120,6 +120,9 @@ class EmbeddingAPIClient:
         if not texts:
             return []
 
+        # 某些 embedding 端点（如 Gemini）拒绝空字符串，用单空格占位保持索引对齐
+        texts = [t if t else " " for t in texts]
+
         timeout = self.config.cold_start_timeout if not self._warmed_up else self.config.normal_timeout
         max_retries = getattr(self.config, 'api_max_retries', 3)
         base_delay = getattr(self.config, 'api_retry_delay', 1.0)


### PR DESCRIPTION
 - Gemini 的 OpenAI 兼容端点不接受空字符串 ""，返回 EmbedContentRequest.content contains an empty Part.
 - 在 EmbeddingAPIClient.embed() 入口将空字符串替换为单空格 " "，保持索引对齐  
 - 魔搭等其他端点不受影响

