### PR TITLE
feat(dashboard): Vietnamese and English i18n support + translated READMEs

### DIFF
--- a/README_en.md
+++ b/README_en.md
@@ -1,0 +1,119 @@
+# Webnovel Writer
+
+[![License](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](LICENSE)
+[![Python](https://img.shields.io/badge/Python-3.10+-blue.svg)](https://www.python.org/)
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-Compatible-purple.svg)](https://claude.ai/claude-code)
+
+<a href="https://trendshift.io/repositories/22487" target="_blank"><img src="https://trendshift.io/api/badge/repositories/22487" alt="lingfengQAQ%2Fwebnovel-writer | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+
+## Project Overview
+
+`Webnovel Writer` is a web novel creation system built on Claude Code. Its goal is to reduce AI "forgetting" and "hallucination" in long-form creative writing, supporting long-cycle serialized storytelling.
+
+Detailed documentation is split across `docs/`:
+
+- Architecture & Modules: `docs/architecture.md`
+- Command Reference: `docs/commands.md`
+- RAG & Configuration: `docs/rag-and-config.md`
+- Genre Templates: `docs/genres.md`
+- Operations & Recovery: `docs/operations.md`
+- Doc Navigation: `docs/README.md`
+
+## Quick Start
+
+### 1) Install the Plugin (Official Marketplace)
+
+```bash
+claude plugin marketplace add lingfengQAQ/webnovel-writer --scope user
+claude plugin install webnovel-writer@webnovel-writer-marketplace --scope user
+```
+
+> For project-scoped only: replace `--scope user` with `--scope project`.
+
+### 2) Install Python Dependencies
+
+```bash
+python -m pip install -r https://raw.githubusercontent.com/lingfengQAQ/webnovel-writer/HEAD/requirements.txt
+```
+
+### 3) Initialize a Novel Project
+
+```bash
+/webnovel-init
+```
+
+### 4) Configure RAG Environment (Required)
+
+Create `.env` in the project root:
+
+```bash
+cp .env.example .env
+```
+
+Minimum configuration:
+
+```bash
+EMBED_BASE_URL=https://api-inference.modelscope.cn/v1
+EMBED_MODEL=Qwen/Qwen3-Embedding-8B
+EMBED_API_KEY=your_embed_api_key
+
+RERANK_BASE_URL=https://api.jina.ai/v1
+RERANK_MODEL=jina-reranker-v3
+RERANK_API_KEY=your_rerank_api_key
+```
+
+### 5) Start Writing
+
+```bash
+/webnovel-plan 1
+/webnovel-write 1
+/webnovel-review 1-5
+```
+
+### 6) Launch the Visual Dashboard (Optional)
+
+```bash
+/webnovel-dashboard
+```
+
+### 7) Agent Model Setup (Optional)
+
+All built-in agents default to `model: inherit` (inherits from the Claude session model). To override, edit `webnovel-writer/agents/*.md` frontmatter with `sonnet`, `opus`, or `haiku`.
+
+## Dashboard — Multi-Language Support
+
+The dashboard supports **3 languages**: Vietnamese, English, and Chinese.
+A language switcher is located in the sidebar — click to switch between languages instantly.
+
+## GitHub Actions — Plugin Release
+
+1. Sync version info locally:
+   ```bash
+   python -X utf8 webnovel-writer/scripts/sync_plugin_version.py --version 5.5.4 --release-notes "Release notes here"
+   ```
+2. Commit and push version changes.
+3. Open Actions → select `Plugin Release`.
+4. Enter `version` and `release_notes`.
+
+## License
+
+This project is licensed under `GPL v3` — see `LICENSE`.
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=lingfengQAQ/webnovel-writer&type=Date)](https://star-history.com/#lingfengQAQ/webnovel-writer&Date)
+
+## Acknowledgments
+
+Built with **Claude Code + Gemini CLI + Codex** via Vibe Coding.
+Inspiration: [Linux.do Thread](https://linux.do/t/topic/1397944/49)
+
+## Contributing
+
+Issues and PRs are welcome:
+
+```bash
+git checkout -b feature/your-feature
+git commit -m "feat: add your feature"
+git push origin feature/your-feature
+```

--- a/README_vi.md
+++ b/README_vi.md
@@ -1,0 +1,120 @@
+# Webnovel Writer
+
+[![License](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](LICENSE)
+[![Python](https://img.shields.io/badge/Python-3.10+-blue.svg)](https://www.python.org/)
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-Compatible-purple.svg)](https://claude.ai/claude-code)
+
+<a href="https://trendshift.io/repositories/22487" target="_blank"><img src="https://trendshift.io/api/badge/repositories/22487" alt="lingfengQAQ%2Fwebnovel-writer | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+
+## Giới Thiệu Dự Án
+
+`Webnovel Writer` là hệ thống sáng tác tiểu thuyết mạng dựa trên Claude Code, với mục tiêu giảm thiểu "lãng quên" và "ảo giác" trong AI, hỗ trợ sáng tác dài hạn cho các bộ truyện nhiều tập.
+
+Chi tiết tài liệu được phân tách trong `docs/`:
+
+- Kiến trúc & Mô-đun: `docs/architecture.md`
+- Hướng dẫn lệnh: `docs/commands.md`
+- RAG & Cấu hình: `docs/rag-and-config.md`
+- Thể loại: `docs/genres.md`
+- Vận hành & Khôi phục: `docs/operations.md`
+- Mục lục: `docs/README.md`
+
+## Bắt Đầu Nhanh
+
+### 1) Cài đặt Plugin (qua Marketplace chính thức)
+
+```bash
+claude plugin marketplace add lingfengQAQ/webnovel-writer --scope user
+claude plugin install webnovel-writer@webnovel-writer-marketplace --scope user
+```
+
+> Chỉ ảnh hưởng dự án hiện tại: thay `--scope user` bằng `--scope project`.
+
+### 2) Cài đặt Phụ thuộc Python
+
+```bash
+python -m pip install -r https://raw.githubusercontent.com/lingfengQAQ/webnovel-writer/HEAD/requirements.txt
+```
+
+### 3) Khởi tạo Dự Án Tiểu Thuyết
+
+```bash
+/webnovel-init
+```
+
+### 4) Cấu hình Môi trường RAG (Bắt buộc)
+
+Tạo `.env` trong thư mục dự án:
+
+```bash
+cp .env.example .env
+```
+
+Cấu hình tối thiểu:
+
+```bash
+EMBED_BASE_URL=https://api-inference.modelscope.cn/v1
+EMBED_MODEL=Qwen/Qwen3-Embedding-8B
+EMBED_API_KEY=your_embed_api_key
+
+RERANK_BASE_URL=https://api.jina.ai/v1
+RERANK_MODEL=jina-reranker-v3
+RERANK_API_KEY=your_rerank_api_key
+```
+
+### 5) Bắt đầu Sáng tác
+
+```bash
+/webnovel-plan 1
+/webnovel-write 1
+/webnovel-review 1-5
+```
+
+### 6) Bảng Điều Khiển Trực Quan (Tùy chọn)
+
+```bash
+/webnovel-dashboard
+```
+
+### 7) Thiết lập Mô hình Agent (Tùy chọn)
+
+Tất cả Agent mặc định kế thừa mô hình Claude Code đang dùng (`model: inherit`).
+Để đặt mô hình riêng cho Agent, chỉnh frontmatter trong `webnovel-writer/agents/*.md`.
+
+## Bảng Điều Khiển - Đa Ngôn Ngữ
+
+Bảng điều khiển hỗ trợ 3 ngôn ngữ: **Tiếng Việt**, **Tiếng Anh**, và **Tiếng Trung**.
+Nút chuyển ngôn ngữ nằm ở sidebar — nhấn để chuyển đổi giữa các ngôn ngữ.
+
+## GitHub Actions — Plugin Release
+
+1. Đồng bộ thông tin phiên bản:
+   ```bash
+   python -X utf8 webnovel-writer/scripts/sync_plugin_version.py --version 5.5.4 --release-notes "Mô tả bản này"
+   ```
+2. Commit & push thay đổi.
+3. Mở Actions → chọn `Plugin Release`.
+4. Nhập `version` và `release_notes`.
+
+## Mã Nguồn Mở
+
+Dự án này sử dụng giấy phép `GPL v3`, xem `LICENSE`.
+
+## Star Lịch Sử
+
+[![Star History Chart](https://api.star-history.com/svg?repos=lingfengQAQ/webnovel-writer&type=Date)](https://star-history.com/#lingfengQAQ/webnovel-writer&Date)
+
+## Lời Cảm Ơn
+
+Dự án này được phát triển với **Claude Code + Gemini CLI + Codex** theo phương thức Vibe Coding.
+Nguồn cảm hứng: [Linux.do帖子](https://linux.do/t/topic/1397944/49)
+
+## Đóng Góp
+
+Chào đón Issue và PR:
+
+```bash
+git checkout -b feature/ten-tinh-nang
+git commit -m "feat: mo ta"
+git push origin feature/ten-tinh-nang
+```

--- a/webnovel-writer/dashboard/frontend/src/App.jsx
+++ b/webnovel-writer/dashboard/frontend/src/App.jsx
@@ -1,889 +1,922 @@
 import { useState, useEffect, useCallback } from 'react'
 import { fetchJSON, subscribeSSE } from './api.js'
+import { I18nProvider, useI18n, LOCALES } from './i18n.jsx'
 import ForceGraph3D from 'react-force-graph-3d'
 
 // ====================================================================
-// 主应用
+// Language Switcher
 // ====================================================================
+function LanguageSwitcher() {
+  const { locale, setLocale, t } = useI18n()
+  return (
+    <div className="lang-switcher">
+      {LOCALES.map(l => (
+        <button
+          key={l.code}
+          className={`lang-btn ${locale === l.code ? 'active' : ''}`}
+          onClick={() => setLocale(l.code)}
+          title={l.label}
+        >
+          {l.label}
+        </button>
+      ))}
+    </div>
+  )
+}
 
+// ====================================================================
+// App (wrapped in I18nProvider)
+// ====================================================================
 export default function App() {
-    const [page, setPage] = useState('dashboard')
-    const [projectInfo, setProjectInfo] = useState(null)
-    const [refreshKey, setRefreshKey] = useState(0)
-    const [connected, setConnected] = useState(false)
+  return (
+    <I18nProvider>
+      <AppInner />
+    </I18nProvider>
+  )
+}
 
-    const loadProjectInfo = useCallback(() => {
-        fetchJSON('/api/project/info')
-            .then(setProjectInfo)
-            .catch(() => setProjectInfo(null))
-    }, [])
+function AppInner() {
+  const { t } = useI18n()
+  const [page, setPage] = useState('dashboard')
+  const [projectInfo, setProjectInfo] = useState(null)
+  const [refreshKey, setRefreshKey] = useState(0)
+  const [connected, setConnected] = useState(false)
 
-    useEffect(() => { loadProjectInfo() }, [loadProjectInfo, refreshKey])
+  const loadProjectInfo = useCallback(() => {
+    fetchJSON('/api/project/info')
+      .then(setProjectInfo)
+      .catch(() => setProjectInfo(null))
+  }, [])
 
-    // SSE 订阅
-    useEffect(() => {
-        const unsub = subscribeSSE(
-            () => {
-                setRefreshKey(k => k + 1)
-            },
-            {
-                onOpen: () => setConnected(true),
-                onError: () => setConnected(false),
-            },
-        )
-        return () => { unsub(); setConnected(false) }
-    }, [])
+  useEffect(() => { loadProjectInfo() }, [loadProjectInfo, refreshKey])
 
-    const title = projectInfo?.project_info?.title || '未加载'
-
-    return (
-        <div className="app-layout">
-            <aside className="sidebar">
-                <div className="sidebar-header">
-                    <h1>PIXEL WRITER HUB</h1>
-                    <div className="subtitle">{title}</div>
-                </div>
-                <nav className="sidebar-nav">
-                    {NAV_ITEMS.map(item => (
-                        <button
-                            key={item.id}
-                            className={`nav-item ${page === item.id ? 'active' : ''}`}
-                            onClick={() => setPage(item.id)}
-                        >
-                            <span className="icon">{item.icon}</span>
-                            <span>{item.label}</span>
-                        </button>
-                    ))}
-                </nav>
-                <div className="live-indicator">
-                    <span className={`live-dot ${connected ? '' : 'disconnected'}`} />
-                    {connected ? '实时同步中' : '未连接'}
-                </div>
-            </aside>
-
-            <main className="main-content">
-                {page === 'dashboard' && <DashboardPage data={projectInfo} key={refreshKey} />}
-                {page === 'entities' && <EntitiesPage key={refreshKey} />}
-                {page === 'graph' && <GraphPage key={refreshKey} />}
-                {page === 'chapters' && <ChaptersPage key={refreshKey} />}
-                {page === 'files' && <FilesPage />}
-                {page === 'reading' && <ReadingPowerPage key={refreshKey} />}
-            </main>
-        </div>
+  // SSE subscription
+  useEffect(() => {
+    const unsub = subscribeSSE(
+      () => setRefreshKey(k => k + 1),
+      { onOpen: () => setConnected(true), onError: () => setConnected(false) },
     )
+    return () => { unsub(); setConnected(false) }
+  }, [])
+
+  const title = projectInfo?.project_info?.title || t('loading')
+
+  return (
+    <div className="app-layout">
+      <aside className="sidebar">
+        <div className="sidebar-header">
+          <h1>PIXEL WRITER HUB</h1>
+          <div className="subtitle">{title}</div>
+        </div>
+        <nav className="sidebar-nav">
+          {NAV_ITEMS.map(item => (
+            <button
+              key={item.id}
+              className={`nav-item ${page === item.id ? 'active' : ''}`}
+              onClick={() => setPage(item.id)}
+            >
+              <span className="icon">{item.icon}</span>
+              <span>{t(`nav.${item.id}`)}</span>
+            </button>
+          ))}
+        </nav>
+        <div className="live-indicator">
+          <span className={`live-dot ${connected ? '' : 'disconnected'}`} />
+          {connected ? t('live.connected') : t('live.disconnected')}
+        </div>
+        <LanguageSwitcher />
+      </aside>
+
+      <main className="main-content">
+        {page === 'dashboard' && <DashboardPage data={projectInfo} key={refreshKey} />}
+        {page === 'entities' && <EntitiesPage key={refreshKey} />}
+        {page === 'graph' && <GraphPage key={refreshKey} />}
+        {page === 'chapters' && <ChaptersPage key={refreshKey} />}
+        {page === 'files' && <FilesPage />}
+        {page === 'reading' && <ReadingPowerPage key={refreshKey} />}
+      </main>
+    </div>
+  )
 }
 
 const NAV_ITEMS = [
-    { id: 'dashboard', icon: '📊', label: '数据总览' },
-    { id: 'entities', icon: '👤', label: '设定词典' },
-    { id: 'graph', icon: '🕸️', label: '关系图谱' },
-    { id: 'chapters', icon: '📝', label: '章节一览' },
-    { id: 'files', icon: '📁', label: '文档浏览' },
-    { id: 'reading', icon: '🔥', label: '追读力' },
+  { id: 'dashboard', icon: '📊', labelKey: 'nav.dashboard' },
+  { id: 'entities', icon: '👤', labelKey: 'nav.entities' },
+  { id: 'graph', icon: '🕸️', labelKey: 'nav.graph' },
+  { id: 'chapters', icon: '📝', labelKey: 'nav.chapters' },
+  { id: 'files', icon: '📁', labelKey: 'nav.files' },
+  { id: 'reading', icon: '🔥', labelKey: 'nav.reading' },
 ]
 
 const FULL_DATA_GROUPS = [
-    { key: 'entities', title: '实体', columns: ['id', 'canonical_name', 'type', 'tier', 'first_appearance', 'last_appearance'], domain: 'core' },
-    { key: 'chapters', title: '章节', columns: ['chapter', 'title', 'word_count', 'location', 'characters'], domain: 'core' },
-    { key: 'scenes', title: '场景', columns: ['chapter', 'scene_index', 'location', 'time', 'summary'], domain: 'core' },
-    { key: 'aliases', title: '别名', columns: ['alias', 'entity_id', 'entity_type'], domain: 'core' },
-    { key: 'stateChanges', title: '状态变化', columns: ['entity_id', 'field', 'old_value', 'new_value', 'chapter'], domain: 'core' },
-    { key: 'relationships', title: '关系', columns: ['from_entity', 'to_entity', 'type', 'chapter', 'description'], domain: 'network' },
-    { key: 'relationshipEvents', title: '关系事件', columns: ['from_entity', 'to_entity', 'type', 'chapter', 'event_type', 'description'], domain: 'network' },
-    { key: 'readingPower', title: '追读力', columns: ['chapter', 'hook_type', 'hook_strength', 'is_transition', 'override_count', 'debt_balance'], domain: 'network' },
-    { key: 'overrides', title: 'Override 合约', columns: ['chapter', 'constraint_type', 'constraint_id', 'due_chapter', 'status'], domain: 'network' },
-    { key: 'debts', title: '追读债务', columns: ['id', 'debt_type', 'current_amount', 'interest_rate', 'due_chapter', 'status'], domain: 'network' },
-    { key: 'debtEvents', title: '债务事件', columns: ['debt_id', 'event_type', 'amount', 'chapter', 'note'], domain: 'network' },
-    { key: 'reviewMetrics', title: '审查指标', columns: ['start_chapter', 'end_chapter', 'overall_score', 'severity_counts', 'created_at'], domain: 'quality' },
-    { key: 'invalidFacts', title: '无效事实', columns: ['source_type', 'source_id', 'reason', 'status', 'chapter_discovered'], domain: 'quality' },
-    { key: 'checklistScores', title: '写作清单评分', columns: ['chapter', 'template', 'score', 'completion_rate', 'completed_items', 'total_items'], domain: 'quality' },
-    { key: 'ragQueries', title: 'RAG 查询日志', columns: ['query_type', 'query', 'results_count', 'latency_ms', 'chapter', 'created_at'], domain: 'ops' },
-    { key: 'toolStats', title: '工具调用统计', columns: ['tool_name', 'success', 'retry_count', 'error_code', 'chapter', 'created_at'], domain: 'ops' },
+  { key: 'entities', titleKey: 'groups.entities', columns: ['id', 'canonical_name', 'type', 'tier', 'first_appearance', 'last_appearance'], domain: 'core' },
+  { key: 'chapters', titleKey: 'groups.chapters', columns: ['chapter', 'title', 'word_count', 'location', 'characters'], domain: 'core' },
+  { key: 'scenes', titleKey: 'groups.scenes', columns: ['chapter', 'scene_index', 'location', 'time', 'summary'], domain: 'core' },
+  { key: 'aliases', titleKey: 'groups.aliases', columns: ['alias', 'entity_id', 'entity_type'], domain: 'core' },
+  { key: 'stateChanges', titleKey: 'groups.stateChanges', columns: ['entity_id', 'field', 'old_value', 'new_value', 'chapter'], domain: 'core' },
+  { key: 'relationships', titleKey: 'groups.relationships', columns: ['from_entity', 'to_entity', 'type', 'chapter', 'description'], domain: 'network' },
+  { key: 'relationshipEvents', titleKey: 'groups.relationshipEvents', columns: ['from_entity', 'to_entity', 'type', 'chapter', 'event_type', 'description'], domain: 'network' },
+  { key: 'readingPower', titleKey: 'groups.readingPower', columns: ['chapter', 'hook_type', 'hook_strength', 'is_transition', 'override_count', 'debt_balance'], domain: 'network' },
+  { key: 'overrides', titleKey: 'groups.overrides', columns: ['chapter', 'constraint_type', 'constraint_id', 'due_chapter', 'status'], domain: 'network' },
+  { key: 'debts', titleKey: 'groups.debts', columns: ['id', 'debt_type', 'current_amount', 'interest_rate', 'due_chapter', 'status'], domain: 'network' },
+  { key: 'debtEvents', titleKey: 'groups.debtEvents', columns: ['debt_id', 'event_type', 'amount', 'chapter', 'note'], domain: 'network' },
+  { key: 'reviewMetrics', titleKey: 'groups.reviewMetrics', columns: ['start_chapter', 'end_chapter', 'overall_score', 'severity_counts', 'created_at'], domain: 'quality' },
+  { key: 'invalidFacts', titleKey: 'groups.invalidFacts', columns: ['source_type', 'source_id', 'reason', 'status', 'chapter_discovered'], domain: 'quality' },
+  { key: 'checklistScores', titleKey: 'groups.checklistScores', columns: ['chapter', 'template', 'score', 'completion_rate', 'completed_items', 'total_items'], domain: 'quality' },
+  { key: 'ragQueries', titleKey: 'groups.ragQueries', columns: ['query_type', 'query', 'results_count', 'latency_ms', 'chapter', 'created_at'], domain: 'ops' },
+  { key: 'toolStats', titleKey: 'groups.toolStats', columns: ['tool_name', 'success', 'retry_count', 'error_code', 'chapter', 'created_at'], domain: 'ops' },
 ]
 
 const FULL_DATA_DOMAINS = [
-    { id: 'overview', label: '总览' },
-    { id: 'core', label: '基础档案' },
-    { id: 'network', label: '关系与剧情' },
-    { id: 'quality', label: '质量审查' },
-    { id: 'ops', label: 'RAG 与工具' },
+  { id: 'overview', labelKey: 'domains.overview' },
+  { id: 'core', labelKey: 'domains.core' },
+  { id: 'network', labelKey: 'domains.network' },
+  { id: 'quality', labelKey: 'domains.quality' },
+  { id: 'ops', labelKey: 'domains.ops' },
 ]
 
 
 // ====================================================================
-// 页面 1：数据总览
+// Page 1: Dashboard
 // ====================================================================
 
 function DashboardPage({ data }) {
-    if (!data) return <div className="loading">加载中…</div>
+  const { t } = useI18n()
+  if (!data) return <div className="loading">{t('loading')}</div>
 
-    const info = data.project_info || {}
-    const progress = data.progress || {}
-    const protagonist = data.protagonist_state || {}
-    const strand = data.strand_tracker || {}
-    const foreshadowing = data.plot_threads?.foreshadowing || []
+  const info = data.project_info || {}
+  const progress = data.progress || {}
+  const protagonist = data.protagonist_state || {}
+  const strand = data.strand_tracker || {}
+  const foreshadowing = data.plot_threads?.foreshadowing || []
 
-    const totalWords = progress.total_words || 0
-    const targetWords = info.target_words || 2000000
-    const pct = targetWords > 0 ? Math.min(100, (totalWords / targetWords * 100)).toFixed(1) : 0
+  const totalWords = progress.total_words || 0
+  const targetWords = info.target_words || 2000000
+  const pct = targetWords > 0 ? Math.min(100, (totalWords / targetWords * 100)).toFixed(1) : 0
 
-    const unresolvedForeshadow = foreshadowing.filter(f => {
-        const s = (f.status || '').toLowerCase()
-        return s !== '已回收' && s !== '已兑现' && s !== 'resolved'
-    })
+  const unresolvedForeshadow = foreshadowing.filter(f => {
+    const s = (f.status || '').toLowerCase()
+    return s !== '已回收' && s !== '已兑现' && s !== 'resolved'
+  })
 
-    // Strand 历史统计
-    const history = strand.history || []
-    const strandCounts = { quest: 0, fire: 0, constellation: 0 }
-    history.forEach(h => { if (strandCounts[h.strand] !== undefined) strandCounts[h.strand]++ })
-    const total = history.length || 1
+  // Strand history
+  const history = strand.history || []
+  const strandCounts = { quest: 0, fire: 0, constellation: 0 }
+  history.forEach(h => { if (strandCounts[h.strand] !== undefined) strandCounts[h.strand]++ })
+  const total = history.length || 1
 
-    return (
-        <>
-            <div className="page-header">
-                <h2>📊 数据总览</h2>
-                <span className="card-badge badge-blue">{info.genre || '未知题材'}</span>
-            </div>
+  return (
+    <>
+      <div className="page-header">
+        <h2>📊 {t('dashboard.title')}</h2>
+        <span className="card-badge badge-blue">{info.genre || t('dashboard.genre')}</span>
+      </div>
 
-            <div className="dashboard-grid">
-                <div className="card stat-card">
-                    <span className="stat-label">总字数</span>
-                    <span className="stat-value">{formatNumber(totalWords)}</span>
-                    <span className="stat-sub">目标 {formatNumber(targetWords)} 字 · {pct}%</span>
-                    <div className="progress-track">
-                        <div className="progress-fill" style={{ width: `${pct}%` }} />
-                    </div>
-                </div>
+      <div className="dashboard-grid">
+        <div className="card stat-card">
+          <span className="stat-label">{t('dashboard.totalWords')}</span>
+          <span className="stat-value">{formatNumber(totalWords)}</span>
+          <span className="stat-sub">{t('dashboard.target')} {formatNumber(targetWords)} {t('dashboard.chars')} · {pct}%</span>
+          <div className="progress-track">
+            <div className="progress-fill" style={{ width: `${pct}%` }} />
+          </div>
+        </div>
 
-                <div className="card stat-card">
-                    <span className="stat-label">当前章节</span>
-                    <span className="stat-value">第 {progress.current_chapter || 0} 章</span>
-                    <span className="stat-sub">目标 {info.target_chapters || '?'} 章 · 卷 {progress.current_volume || 1}</span>
-                </div>
+        <div className="card stat-card">
+          <span className="stat-label">{t('dashboard.currentChapter')}</span>
+          <span className="stat-value">{t('chapters.chPrefix')} {progress.current_chapter || 0} {t('chapters.title')}</span>
+          <span className="stat-sub">{t('dashboard.target')} {info.target_chapters || '?'} {t('chapters.title')} · {t('dashboard.vol')} {progress.current_volume || 1}</span>
+        </div>
 
-                <div className="card stat-card">
-                    <span className="stat-label">主角状态</span>
-                    <span className="stat-value plain">{protagonist.name || '未设定'}</span>
-                    <span className="stat-sub">
-                        {protagonist.power?.realm || '未知境界'}
-                        {protagonist.location?.current ? ` · ${protagonist.location.current}` : ''}
-                    </span>
-                </div>
+        <div className="card stat-card">
+          <span className="stat-label">{t('dashboard.protagonist')}</span>
+          <span className="stat-value plain">{protagonist.name || t('dashboard.notSet')}</span>
+          <span className="stat-sub">
+            {protagonist.power?.realm || t('dashboard.unknownRealm')}
+            {protagonist.location?.current ? ` · ${protagonist.location.current}` : ''}
+          </span>
+        </div>
 
-                <div className="card stat-card">
-                    <span className="stat-label">未回收伏笔</span>
-                    <span className="stat-value" style={{ color: unresolvedForeshadow.length > 10 ? 'var(--accent-red)' : 'var(--accent-amber)' }}>
-                        {unresolvedForeshadow.length}
-                    </span>
-                    <span className="stat-sub">总计 {foreshadowing.length} 条伏笔</span>
-                </div>
-            </div>
+        <div className="card stat-card">
+          <span className="stat-label">{t('dashboard.unresolvedForeshadow')}</span>
+          <span className="stat-value" style={{ color: unresolvedForeshadow.length > 10 ? 'var(--accent-red)' : 'var(--accent-amber)' }}>
+            {unresolvedForeshadow.length}
+          </span>
+          <span className="stat-sub">{t('dashboard.totalForeshadow')} {foreshadowing.length} {t('dashboard.foreshadowUnit')}</span>
+        </div>
+      </div>
 
-            {/* Strand Weave 比例 */}
-            <div className="card dashboard-section-card">
-                <div className="card-header">
-                    <span className="card-title">Strand Weave 节奏分布</span>
-                    <span className="card-badge badge-purple">{strand.current_dominant || '?'}</span>
-                </div>
-                <div className="strand-bar">
-                    <div className="segment strand-quest" style={{ width: `${(strandCounts.quest / total * 100).toFixed(1)}%` }} />
-                    <div className="segment strand-fire" style={{ width: `${(strandCounts.fire / total * 100).toFixed(1)}%` }} />
-                    <div className="segment strand-constellation" style={{ width: `${(strandCounts.constellation / total * 100).toFixed(1)}%` }} />
-                </div>
-                <div className="strand-legend">
-                    <span>🔵 Quest {(strandCounts.quest / total * 100).toFixed(0)}%</span>
-                    <span>🔴 Fire {(strandCounts.fire / total * 100).toFixed(0)}%</span>
-                    <span>🟣 Constellation {(strandCounts.constellation / total * 100).toFixed(0)}%</span>
-                </div>
-            </div>
+      {/* Strand Weave */}
+      <div className="card dashboard-section-card">
+        <div className="card-header">
+          <span className="card-title">{t('dashboard.strandTitle')}</span>
+          <span className="card-badge badge-purple">{strand.current_dominant || '?'}</span>
+        </div>
+        <div className="strand-bar">
+          <div className="segment strand-quest" style={{ width: `${(strandCounts.quest / total * 100).toFixed(1)}%` }} />
+          <div className="segment strand-fire" style={{ width: `${(strandCounts.fire / total * 100).toFixed(1)}%` }} />
+          <div className="segment strand-constellation" style={{ width: `${(strandCounts.constellation / total * 100).toFixed(1)}%` }} />
+        </div>
+        <div className="strand-legend">
+          <span>🔵 Quest {(strandCounts.quest / total * 100).toFixed(0)}%</span>
+          <span>🔴 Fire {(strandCounts.fire / total * 100).toFixed(0)}%</span>
+          <span>🟣 Constellation {(strandCounts.constellation / total * 100).toFixed(0)}%</span>
+        </div>
+      </div>
 
-            {/* 伏笔列表 */}
-            {unresolvedForeshadow.length > 0 ? (
-                <div className="card dashboard-section-card">
-                    <div className="card-header">
-                        <span className="card-title">⚠️ 待回收伏笔 (Top 20)</span>
-                    </div>
-                    <div className="table-wrap">
-                        <table className="data-table">
-                            <thead><tr><th>内容</th><th>状态</th><th>埋设章</th></tr></thead>
-                            <tbody>
-                                {unresolvedForeshadow.slice(0, 20).map((f, i) => (
-                                    <tr key={i}>
-                                        <td className="truncate" style={{ maxWidth: 400 }}>{f.content || f.description || '—'}</td>
-                                        <td><span className="card-badge badge-amber">{f.status || '未知'}</span></td>
-                                        <td>{f.chapter || f.planted_chapter || '—'}</td>
-                                    </tr>
-                                ))}
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-            ) : null}
+      {/* Foreshadowing */}
+      {unresolvedForeshadow.length > 0 ? (
+        <div className="card dashboard-section-card">
+          <div className="card-header">
+            <span className="card-title">⚠️ {t('dashboard.pendingForeshadow')}</span>
+          </div>
+          <div className="table-wrap">
+            <table className="data-table">
+              <thead><tr><th>{t('dashboard.content')}</th><th>{t('dashboard.status')}</th><th>{t('dashboard.plantedCh')}</th></tr></thead>
+              <tbody>
+                {unresolvedForeshadow.slice(0, 20).map((f, i) => (
+                  <tr key={i}>
+                    <td className="truncate" style={{ maxWidth: 400 }}>{f.content || f.description || '—'}</td>
+                    <td><span className="card-badge badge-amber">{f.status || t('dashboard.status')}</span></td>
+                    <td>{f.chapter || f.planted_chapter || '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ) : null}
 
-            <MergedDataView />
-        </>
-    )
+      <MergedDataView />
+    </>
+  )
 }
 
 
 // ====================================================================
-// 页面 2：设定词典
+// Page 2: Entities
 // ====================================================================
 
 function EntitiesPage() {
-    const [entities, setEntities] = useState([])
-    const [typeFilter, setTypeFilter] = useState('')
-    const [selected, setSelected] = useState(null)
-    const [changes, setChanges] = useState([])
+  const { t } = useI18n()
+  const [entities, setEntities] = useState([])
+  const [typeFilter, setTypeFilter] = useState('')
+  const [selected, setSelected] = useState(null)
+  const [changes, setChanges] = useState([])
 
-    useEffect(() => {
-        fetchJSON('/api/entities').then(setEntities).catch(() => { })
-    }, [])
+  useEffect(() => {
+    fetchJSON('/api/entities').then(setEntities).catch(() => { })
+  }, [])
 
-    useEffect(() => {
-        if (selected) {
-            fetchJSON('/api/state-changes', { entity: selected.id, limit: 30 }).then(setChanges).catch(() => setChanges([]))
-        }
-    }, [selected])
+  useEffect(() => {
+    if (selected) {
+      fetchJSON('/api/state-changes', { entity: selected.id, limit: 30 }).then(setChanges).catch(() => setChanges([]))
+    }
+  }, [selected])
 
-    const types = [...new Set(entities.map(e => e.type))].sort()
-    const filteredEntities = typeFilter ? entities.filter(e => e.type === typeFilter) : entities
+  const types = [...new Set(entities.map(e => e.type))].sort()
+  const filteredEntities = typeFilter ? entities.filter(e => e.type === typeFilter) : entities
 
-    return (
-        <>
-            <div className="page-header">
-                <h2>👤 设定词典</h2>
-                <span className="card-badge badge-green">{filteredEntities.length} / {entities.length} 个实体</span>
+  return (
+    <>
+      <div className="page-header">
+        <h2>👤 {t('entities.title')}</h2>
+        <span className="card-badge badge-green">{filteredEntities.length} / {entities.length} {t('entities.units')}</span>
+      </div>
+
+      <div className="filter-group">
+        <button className={`filter-btn ${typeFilter === '' ? 'active' : ''}`} onClick={() => setTypeFilter('')}>{t('entities.all')}</button>
+        {types.map(ty => (
+          <button key={ty} className={`filter-btn ${typeFilter === ty ? 'active' : ''}`} onClick={() => setTypeFilter(ty)}>{ty}</button>
+        ))}
+      </div>
+
+      <div className="split-layout">
+        <div className="split-main">
+          <div className="card">
+            <div className="table-wrap">
+              <table className="data-table">
+                <thead><tr><th>{t('entities.name')}</th><th>{t('entities.type')}</th><th>{t('entities.tier')}</th><th>{t('entities.first')}</th><th>{t('entities.last')}</th></tr></thead>
+                <tbody>
+                  {filteredEntities.map(e => (
+                    <tr
+                      key={e.id}
+                      role="button"
+                      tabIndex={0}
+                      className={`entity-row ${selected?.id === e.id ? 'selected' : ''}`}
+                      onKeyDown={evt => (evt.key === 'Enter' || evt.key === ' ') && (evt.preventDefault(), setSelected(e))}
+                      onClick={() => setSelected(e)}
+                    >
+                      <td className={e.is_protagonist ? 'entity-name protagonist' : 'entity-name'}>
+                        {e.canonical_name} {e.is_protagonist ? '⭐' : ''}
+                      </td>
+                      <td><span className="card-badge badge-blue">{e.type}</span></td>
+                      <td>{e.tier}</td>
+                      <td>{e.first_appearance || '—'}</td>
+                      <td>{e.last_appearance || '—'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
+          </div>
+        </div>
 
-            <div className="filter-group">
-                <button className={`filter-btn ${typeFilter === '' ? 'active' : ''}`} onClick={() => setTypeFilter('')}>全部</button>
-                {types.map(t => (
-                    <button key={t} className={`filter-btn ${typeFilter === t ? 'active' : ''}`} onClick={() => setTypeFilter(t)}>{t}</button>
-                ))}
-            </div>
-
-            <div className="split-layout">
-                <div className="split-main">
-                    <div className="card">
-                        <div className="table-wrap">
-                            <table className="data-table">
-                                <thead><tr><th>名称</th><th>类型</th><th>层级</th><th>首现</th><th>末现</th></tr></thead>
-                                <tbody>
-                                    {filteredEntities.map(e => (
-                                        <tr
-                                            key={e.id}
-                                            role="button"
-                                            tabIndex={0}
-                                            className={`entity-row ${selected?.id === e.id ? 'selected' : ''}`}
-                                            onKeyDown={evt => (evt.key === 'Enter' || evt.key === ' ') && (evt.preventDefault(), setSelected(e))}
-                                            onClick={() => setSelected(e)}
-                                        >
-                                            <td className={e.is_protagonist ? 'entity-name protagonist' : 'entity-name'}>
-                                                {e.canonical_name} {e.is_protagonist ? '⭐' : ''}
-                                            </td>
-                                            <td><span className="card-badge badge-blue">{e.type}</span></td>
-                                            <td>{e.tier}</td>
-                                            <td>{e.first_appearance || '—'}</td>
-                                            <td>{e.last_appearance || '—'}</td>
-                                        </tr>
-                                    ))}
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                </div>
-
-                {selected && (
-                    <div className="split-side">
-                        <div className="card">
-                            <div className="card-header">
-                                <span className="card-title">{selected.canonical_name}</span>
-                                <span className="card-badge badge-purple">{selected.tier}</span>
-                            </div>
-                            <div className="entity-detail">
-                                <p><strong>类型：</strong>{selected.type}</p>
-                                <p><strong>ID：</strong><code>{selected.id}</code></p>
-                                {selected.desc && <p className="entity-desc">{selected.desc}</p>}
-                                {selected.current_json && (
-                                    <div className="entity-current-block">
-                                        <strong>当前状态：</strong>
-                                        <pre className="entity-json">
-                                            {formatJSON(selected.current_json)}
-                                        </pre>
-                                    </div>
-                                )}
-                            </div>
-                            {changes.length > 0 ? (
-                                <div className="entity-history">
-                                    <div className="card-title">状态变化历史</div>
-                                    <div className="table-wrap">
-                                        <table className="data-table">
-                                            <thead><tr><th>章</th><th>字段</th><th>变化</th></tr></thead>
-                                            <tbody>
-                                                {changes.map((c, i) => (
-                                                    <tr key={i}>
-                                                        <td>{c.chapter}</td>
-                                                        <td>{c.field}</td>
-                                                        <td>{c.old_value} → {c.new_value}</td>
-                                                    </tr>
-                                                ))}
-                                            </tbody>
-                                        </table>
-                                    </div>
-                                </div>
-                            ) : null}
-                        </div>
-                    </div>
+        {selected && (
+          <div className="split-side">
+            <div className="card">
+              <div className="card-header">
+                <span className="card-title">{selected.canonical_name}</span>
+                <span className="card-badge badge-purple">{selected.tier}</span>
+              </div>
+              <div className="entity-detail">
+                <p><strong>{t('entityDetail.typeLabel')}：</strong>{selected.type}</p>
+                <p><strong>{t('entityDetail.idLabel')}：</strong><code>{selected.id}</code></p>
+                {selected.desc && <p className="entity-desc">{selected.desc}</p>}
+                {selected.current_json && (
+                  <div className="entity-current-block">
+                    <strong>{t('entityDetail.currentLabel')}：</strong>
+                    <pre className="entity-json">
+                      {formatJSON(selected.current_json)}
+                    </pre>
+                  </div>
                 )}
+              </div>
+              {changes.length > 0 ? (
+                <div className="entity-history">
+                  <div className="card-title">{t('entities.historyTitle')}</div>
+                  <div className="table-wrap">
+                    <table className="data-table">
+                      <thead><tr><th>{t('entities.chapter')}</th><th>{t('entities.field')}</th><th>{t('entities.change')}</th></tr></thead>
+                      <tbody>
+                        {changes.map((c, i) => (
+                          <tr key={i}>
+                            <td>{c.chapter}</td>
+                            <td>{c.field}</td>
+                            <td>{c.old_value} → {c.new_value}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              ) : null}
             </div>
-        </>
-    )
+          </div>
+        )}
+      </div>
+    </>
+  )
 }
 
 
 // ====================================================================
-// 页面 3：3D 宇宙关系图谱
+// Page 3: 3D Graph
 // ====================================================================
 
 function GraphPage() {
-    const [relationships, setRelationships] = useState([])
-    const [graphData, setGraphData] = useState({ nodes: [], links: [] })
+  const { t } = useI18n()
+  const [relationships, setRelationships] = useState([])
+  const [graphData, setGraphData] = useState({ nodes: [], links: [] })
 
-    useEffect(() => {
-        Promise.all([
-            fetchJSON('/api/relationships', { limit: 1000 }),
-            fetchJSON('/api/entities'),
-        ]).then(([rels, ents]) => {
-            setRelationships(rels)
-            const typeColors = {
-                '角色': '#4f8ff7', '地点': '#34d399', '星球': '#22d3ee', '神仙': '#f59e0b',
-                '势力': '#8b5cf6', '招式': '#ef4444', '法宝': '#ec4899'
-            }
-            const relatedIds = new Set()
-            rels.forEach(r => { relatedIds.add(r.from_entity); relatedIds.add(r.to_entity) })
-            const entityMap = {}
-            ents.forEach(e => { entityMap[e.id] = e })
+  useEffect(() => {
+    Promise.all([
+      fetchJSON('/api/relationships', { limit: 1000 }),
+      fetchJSON('/api/entities'),
+    ]).then(([rels, ents]) => {
+      setRelationships(rels)
+      const typeColors = {
+        '角色': '#4f8ff7', '地点': '#34d399', '星球': '#22d3ee', '神仙': '#f59e0b',
+        '势力': '#8b5cf6', '招式': '#ef4444', '法宝': '#ec4899'
+      }
+      const relatedIds = new Set()
+      rels.forEach(r => { relatedIds.add(r.from_entity); relatedIds.add(r.to_entity) })
+      const entityMap = {}
+      ents.forEach(e => { entityMap[e.id] = e })
 
-            const nodes = [...relatedIds].map(id => ({
-                id,
-                name: entityMap[id]?.canonical_name || id,
-                val: (entityMap[id]?.tier === 'S' ? 8 : entityMap[id]?.tier === 'A' ? 5 : 2),
-                color: typeColors[entityMap[id]?.type] || '#5c6078'
-            }))
-            const links = rels.map(r => ({
-                source: r.from_entity,
-                target: r.to_entity,
-                name: r.type
-            }))
-            setGraphData({ nodes, links })
-        }).catch(() => { })
-    }, [])
+      const nodes = [...relatedIds].map(id => ({
+        id,
+        name: entityMap[id]?.canonical_name || id,
+        val: (entityMap[id]?.tier === 'S' ? 8 : entityMap[id]?.tier === 'A' ? 5 : 2),
+        color: typeColors[entityMap[id]?.type] || '#5c6078'
+      }))
+      const links = rels.map(r => ({
+        source: r.from_entity,
+        target: r.to_entity,
+        name: r.type
+      }))
+      setGraphData({ nodes, links })
+    }).catch(() => { })
+  }, [])
 
-    return (
-        <>
-            <div className="page-header">
-                <h2>🕸️ 关系图谱</h2>
-                <span className="card-badge badge-blue">{relationships.length} 条引力链接</span>
-            </div>
-            <div className="card graph-shell">
-                <ForceGraph3D
-                    graphData={graphData}
-                    nodeLabel="name"
-                    nodeColor="color"
-                    nodeRelSize={6}
-                    linkColor={() => 'rgba(127, 90, 240, 0.35)'}
-                    linkWidth={1}
-                    linkDirectionalParticles={2}
-                    linkDirectionalParticleWidth={1.5}
-                    linkDirectionalParticleSpeed={d => 0.005 + Math.random() * 0.005}
-                    backgroundColor="#fffaf0"
-                    showNavInfo={false}
-                />
-            </div>
-        </>
-    )
+  return (
+    <>
+      <div className="page-header">
+        <h2>🕸️ {t('graph.title')}</h2>
+        <span className="card-badge badge-blue">{relationships.length} {t('graph.links')}</span>
+      </div>
+      <div className="card graph-shell">
+        <ForceGraph3D
+          graphData={graphData}
+          nodeLabel="name"
+          nodeColor="color"
+          nodeRelSize={6}
+          linkColor={() => 'rgba(127, 90, 240, 0.35)'}
+          linkWidth={1}
+          linkDirectionalParticles={2}
+          linkDirectionalParticleWidth={1.5}
+          linkDirectionalParticleSpeed={d => 0.005 + Math.random() * 0.005}
+          backgroundColor="#fffaf0"
+          showNavInfo={false}
+        />
+      </div>
+    </>
+  )
 }
 
 
-
 // ====================================================================
-// 页面 4：章节一览
+// Page 4: Chapters
 // ====================================================================
 
 function ChaptersPage() {
-    const [chapters, setChapters] = useState([])
+  const { t } = useI18n()
+  const [chapters, setChapters] = useState([])
 
-    useEffect(() => {
-        fetchJSON('/api/chapters').then(setChapters).catch(() => { })
-    }, [])
+  useEffect(() => {
+    fetchJSON('/api/chapters').then(setChapters).catch(() => { })
+  }, [])
 
-    const totalWords = chapters.reduce((s, c) => s + (c.word_count || 0), 0)
+  const totalWords = chapters.reduce((s, c) => s + (c.word_count || 0), 0)
 
-    return (
-        <>
-            <div className="page-header">
-                <h2>📝 章节一览</h2>
-                <span className="card-badge badge-green">{chapters.length} 章 · {formatNumber(totalWords)} 字</span>
-            </div>
-            <div className="card">
-                <div className="table-wrap">
-                    <table className="data-table">
-                        <thead><tr><th>章节</th><th>标题</th><th>字数</th><th>地点</th><th>角色</th></tr></thead>
-                        <tbody>
-                            {chapters.map(c => (
-                                <tr key={c.chapter}>
-                                    <td className="chapter-no">第 {c.chapter} 章</td>
-                                    <td>{c.title || '—'}</td>
-                                    <td>{formatNumber(c.word_count || 0)}</td>
-                                    <td>{c.location || '—'}</td>
-                                    <td className="truncate chapter-characters">{c.characters || '—'}</td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
-                {chapters.length === 0 ? <div className="empty-state"><div className="empty-icon">📭</div><p>暂无章节数据</p></div> : null}
-            </div>
-        </>
-    )
+  return (
+    <>
+      <div className="page-header">
+        <h2>📝 {t('chapters.title')}</h2>
+        <span className="card-badge badge-green">{chapters.length} {t('chapters.title')} · {formatNumber(totalWords)} {t('dashboard.chars')}</span>
+      </div>
+      <div className="card">
+        <div className="table-wrap">
+          <table className="data-table">
+            <thead><tr><th>{t('chapters.chapter')}</th><th>{t('chapters.titleCol')}</th><th>{t('chapters.wordCount')}</th><th>{t('chapters.location')}</th><th>{t('chapters.characters')}</th></tr></thead>
+            <tbody>
+              {chapters.map(c => (
+                <tr key={c.chapter}>
+                  <td className="chapter-no">{t('chapters.chPrefix')} {c.chapter}</td>
+                  <td>{c.title || '—'}</td>
+                  <td>{formatNumber(c.word_count || 0)}</td>
+                  <td>{c.location || '—'}</td>
+                  <td className="truncate chapter-characters">{c.characters || '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        {chapters.length === 0 ? <div className="empty-state"><div className="empty-icon">📭</div><p>{t('chapters.noChapters')}</p></div> : null}
+      </div>
+    </>
+  )
 }
 
 
 // ====================================================================
-// 页面 5：文档浏览
+// Page 5: Files
 // ====================================================================
 
 function FilesPage() {
-    const [tree, setTree] = useState({})
-    const [selectedPath, setSelectedPath] = useState(null)
-    const [content, setContent] = useState('')
+  const { t } = useI18n()
+  const [tree, setTree] = useState({})
+  const [selectedPath, setSelectedPath] = useState(null)
+  const [content, setContent] = useState('')
 
-    useEffect(() => {
-        fetchJSON('/api/files/tree').then(setTree).catch(() => { })
-    }, [])
+  useEffect(() => {
+    fetchJSON('/api/files/tree').then(setTree).catch(() => { })
+  }, [])
 
-    useEffect(() => {
-        if (selectedPath) {
-            fetchJSON('/api/files/read', { path: selectedPath })
-                .then(d => setContent(d.content))
-                .catch(() => setContent('[读取失败]'))
-        }
-    }, [selectedPath])
+  useEffect(() => {
+    if (selectedPath) {
+      fetchJSON('/api/files/read', { path: selectedPath })
+        .then(d => setContent(d.content))
+        .catch(() => setContent(t('files.readFailed')))
+    }
+  }, [selectedPath])
 
-    useEffect(() => {
-        if (selectedPath) return
-        const first = findFirstFilePath(tree)
-        if (first) setSelectedPath(first)
-    }, [tree, selectedPath])
+  useEffect(() => {
+    if (selectedPath) return
+    const first = findFirstFilePath(tree)
+    if (first) setSelectedPath(first)
+  }, [tree, selectedPath])
 
-    return (
-        <>
-            <div className="page-header">
-                <h2>📁 文档浏览</h2>
+  return (
+    <>
+      <div className="page-header">
+        <h2>📁 {t('files.title')}</h2>
+      </div>
+      <div className="file-layout">
+        <div className="file-tree-pane">
+          {Object.entries(tree).map(([folder, items]) => (
+            <div key={folder} className="folder-block">
+              <div className="folder-title">📂 {folder}</div>
+              <ul className="file-tree">
+                <TreeNodes items={items} selected={selectedPath} onSelect={setSelectedPath} />
+              </ul>
             </div>
-            <div className="file-layout">
-                <div className="file-tree-pane">
-                    {Object.entries(tree).map(([folder, items]) => (
-                        <div key={folder} className="folder-block">
-                            <div className="folder-title">📂 {folder}</div>
-                            <ul className="file-tree">
-                                <TreeNodes items={items} selected={selectedPath} onSelect={setSelectedPath} />
-                            </ul>
-                        </div>
-                    ))}
-                </div>
-                <div className="file-content-pane">
-                    {selectedPath ? (
-                        <div>
-                            <div className="selected-path">{selectedPath}</div>
-                            <div className="file-preview">{content}</div>
-                        </div>
-                    ) : (
-                        <div className="empty-state"><div className="empty-icon">📄</div><p>选择左侧文件以预览内容</p></div>
-                    )}
-                </div>
+          ))}
+        </div>
+        <div className="file-content-pane">
+          {selectedPath ? (
+            <div>
+              <div className="selected-path">{selectedPath}</div>
+              <div className="file-preview">{content}</div>
             </div>
-        </>
-    )
+          ) : (
+            <div className="empty-state"><div className="empty-icon">📄</div><p>{t('files.selectFile')}</p></div>
+          )}
+        </div>
+      </div>
+    </>
+  )
 }
 
 
 // ====================================================================
-// 页面 6：追读力
+// Page 6: Reading Power
 // ====================================================================
 
 function ReadingPowerPage() {
-    const [data, setData] = useState([])
+  const { t } = useI18n()
+  const [data, setData] = useState([])
 
-    useEffect(() => {
-        fetchJSON('/api/reading-power', { limit: 50 }).then(setData).catch(() => { })
-    }, [])
+  useEffect(() => {
+    fetchJSON('/api/reading-power', { limit: 50 }).then(setData).catch(() => { })
+  }, [])
 
-    return (
-        <>
-            <div className="page-header">
-                <h2>🔥 追读力分析</h2>
-                <span className="card-badge badge-amber">{data.length} 章数据</span>
-            </div>
-            <div className="card">
-                <div className="table-wrap">
-                    <table className="data-table">
-                        <thead><tr><th>章节</th><th>钩子类型</th><th>钩子强度</th><th>过渡章</th><th>Override</th><th>债务余额</th></tr></thead>
-                        <tbody>
-                            {data.map(r => (
-                                <tr key={r.chapter}>
-                                    <td className="chapter-no">第 {r.chapter} 章</td>
-                                    <td>{r.hook_type || '—'}</td>
-                                    <td>
-                                        <span className={`card-badge ${r.hook_strength === 'strong' ? 'badge-green' : r.hook_strength === 'weak' ? 'badge-red' : 'badge-amber'}`}>
-                                            {r.hook_strength || '—'}
-                                        </span>
-                                    </td>
-                                    <td>{r.is_transition ? '✅' : '—'}</td>
-                                    <td>{r.override_count || 0}</td>
-                                    <td className={r.debt_balance > 0 ? 'debt-positive' : 'debt-normal'}>{(r.debt_balance || 0).toFixed(2)}</td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
-                {data.length === 0 ? <div className="empty-state"><div className="empty-icon">🔥</div><p>暂无追读力数据</p></div> : null}
-            </div>
-        </>
-    )
+  return (
+    <>
+      <div className="page-header">
+        <h2>🔥 {t('reading.title')}</h2>
+        <span className="card-badge badge-amber">{data.length} {t('reading.chapterData')}</span>
+      </div>
+      <div className="card">
+        <div className="table-wrap">
+          <table className="data-table">
+            <thead><tr><th>{t('reading.chapterCol')}</th><th>{t('reading.hookType')}</th><th>{t('reading.hookStrength')}</th><th>{t('reading.transition')}</th><th>{t('reading.override')}</th><th>{t('reading.debtBalance')}</th></tr></thead>
+            <tbody>
+              {data.map(r => (
+                <tr key={r.chapter}>
+                  <td className="chapter-no">{t('chapters.chPrefix')} {r.chapter}</td>
+                  <td>{r.hook_type || '—'}</td>
+                  <td>
+                    <span className={`card-badge ${r.hook_strength === 'strong' ? 'badge-green' : r.hook_strength === 'weak' ? 'badge-red' : 'badge-amber'}`}>
+                      {r.hook_strength || '—'}
+                    </span>
+                  </td>
+                  <td>{r.is_transition ? '✅' : '—'}</td>
+                  <td>{r.override_count || 0}</td>
+                  <td className={r.debt_balance > 0 ? 'debt-positive' : 'debt-normal'}>{(r.debt_balance || 0).toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        {data.length === 0 ? <div className="empty-state"><div className="empty-icon">🔥</div><p>{t('reading.noData')}</p></div> : null}
+      </div>
+    </>
+  )
 }
 
 function findFirstFilePath(tree) {
-    const roots = Object.values(tree || {})
-    for (const items of roots) {
-        const p = walkFirstFile(items)
-        if (p) return p
-    }
-    return null
+  const roots = Object.values(tree || {})
+  for (const items of roots) {
+    const p = walkFirstFile(items)
+    if (p) return p
+  }
+  return null
 }
 
 function walkFirstFile(items) {
-    if (!Array.isArray(items)) return null
-    for (const item of items) {
-        if (item?.type === 'file' && item?.path) return item.path
-        if (item?.type === 'dir' && Array.isArray(item.children)) {
-            const p = walkFirstFile(item.children)
-            if (p) return p
-        }
+  if (!Array.isArray(items)) return null
+  for (const item of items) {
+    if (item?.type === 'file' && item?.path) return item.path
+    if (item?.type === 'dir' && Array.isArray(item.children)) {
+      const p = walkFirstFile(item.children)
+      if (p) return p
     }
-    return null
+  }
+  return null
 }
 
 
 // ====================================================================
-// 数据总览内嵌：全量数据视图
+// Merged Data View
 // ====================================================================
 
 function MergedDataView() {
-    const [loading, setLoading] = useState(true)
-    const [payload, setPayload] = useState({})
-    const [domain, setDomain] = useState('overview')
+  const { t } = useI18n()
+  const [loading, setLoading] = useState(true)
+  const [payload, setPayload] = useState({})
+  const [domain, setDomain] = useState('overview')
 
-    useEffect(() => {
-        let disposed = false
+  useEffect(() => {
+    let disposed = false
 
-        async function loadAll() {
-            setLoading(true)
-            const requests = [
-                ['entities', fetchJSON('/api/entities')],
-                ['chapters', fetchJSON('/api/chapters')],
-                ['scenes', fetchJSON('/api/scenes', { limit: 200 })],
-                ['relationships', fetchJSON('/api/relationships', { limit: 300 })],
-                ['relationshipEvents', fetchJSON('/api/relationship-events', { limit: 200 })],
-                ['readingPower', fetchJSON('/api/reading-power', { limit: 100 })],
-                ['reviewMetrics', fetchJSON('/api/review-metrics', { limit: 50 })],
-                ['stateChanges', fetchJSON('/api/state-changes', { limit: 120 })],
-                ['aliases', fetchJSON('/api/aliases')],
-                ['overrides', fetchJSON('/api/overrides', { limit: 120 })],
-                ['debts', fetchJSON('/api/debts', { limit: 120 })],
-                ['debtEvents', fetchJSON('/api/debt-events', { limit: 150 })],
-                ['invalidFacts', fetchJSON('/api/invalid-facts', { limit: 120 })],
-                ['ragQueries', fetchJSON('/api/rag-queries', { limit: 150 })],
-                ['toolStats', fetchJSON('/api/tool-stats', { limit: 200 })],
-                ['checklistScores', fetchJSON('/api/checklist-scores', { limit: 120 })],
-            ]
+    async function loadAll() {
+      setLoading(true)
+      const requests = [
+        ['entities', fetchJSON('/api/entities')],
+        ['chapters', fetchJSON('/api/chapters')],
+        ['scenes', fetchJSON('/api/scenes', { limit: 200 })],
+        ['relationships', fetchJSON('/api/relationships', { limit: 300 })],
+        ['relationshipEvents', fetchJSON('/api/relationship-events', { limit: 200 })],
+        ['readingPower', fetchJSON('/api/reading-power', { limit: 100 })],
+        ['reviewMetrics', fetchJSON('/api/review-metrics', { limit: 50 })],
+        ['stateChanges', fetchJSON('/api/state-changes', { limit: 120 })],
+        ['aliases', fetchJSON('/api/aliases')],
+        ['overrides', fetchJSON('/api/overrides', { limit: 120 })],
+        ['debts', fetchJSON('/api/debts', { limit: 120 })],
+        ['debtEvents', fetchJSON('/api/debt-events', { limit: 150 })],
+        ['invalidFacts', fetchJSON('/api/invalid-facts', { limit: 120 })],
+        ['ragQueries', fetchJSON('/api/rag-queries', { limit: 150 })],
+        ['toolStats', fetchJSON('/api/tool-stats', { limit: 200 })],
+        ['checklistScores', fetchJSON('/api/checklist-scores', { limit: 120 })],
+      ]
 
-            const entries = await Promise.all(
-                requests.map(async ([key, p]) => {
-                    try {
-                        const val = await p
-                        return [key, val]
-                    } catch {
-                        return [key, []]
-                    }
-                }),
-            )
-            if (!disposed) {
-                setPayload(Object.fromEntries(entries))
-                setLoading(false)
-            }
-        }
+      const entries = await Promise.all(
+        requests.map(async ([key, p]) => {
+          try {
+            const val = await p
+            return [key, val]
+          } catch {
+            return [key, []]
+          }
+        }),
+      )
+      if (!disposed) {
+        setPayload(Object.fromEntries(entries))
+        setLoading(false)
+      }
+    }
 
-        loadAll()
-        return () => { disposed = true }
-    }, [])
+    loadAll()
+    return () => { disposed = true }
+  }, [])
 
-    if (loading) return <div className="loading">加载全量数据中…</div>
+  if (loading) return <div className="loading">{t('loading')}</div>
 
-    const groups = domain === 'overview'
-        ? FULL_DATA_GROUPS
-        : FULL_DATA_GROUPS.filter(g => g.domain === domain)
-    const totalRows = FULL_DATA_GROUPS.reduce((sum, g) => sum + (payload[g.key] || []).length, 0)
-    const nonEmptyGroups = FULL_DATA_GROUPS.filter(g => (payload[g.key] || []).length > 0).length
-    const maxChapter = FULL_DATA_GROUPS.reduce((max, g) => {
-        const rows = payload[g.key] || []
-        rows.slice(0, 120).forEach(r => {
-            const c = extractChapter(r)
-            if (c > max) max = c
-        })
-        return max
-    }, 0)
-    const domainStats = FULL_DATA_DOMAINS.filter(d => d.id !== 'overview').map(d => {
-        const ds = FULL_DATA_GROUPS.filter(g => g.domain === d.id)
-        const rowCount = ds.reduce((sum, g) => sum + (payload[g.key] || []).length, 0)
-        const filled = ds.filter(g => (payload[g.key] || []).length > 0).length
-        return { ...d, rowCount, filled, total: ds.length }
+  const groups = domain === 'overview'
+    ? FULL_DATA_GROUPS
+    : FULL_DATA_GROUPS.filter(g => g.domain === domain)
+  const totalRows = FULL_DATA_GROUPS.reduce((sum, g) => sum + (payload[g.key] || []).length, 0)
+  const nonEmptyGroups = FULL_DATA_GROUPS.filter(g => (payload[g.key] || []).length > 0).length
+  const maxChapter = FULL_DATA_GROUPS.reduce((max, g) => {
+    const rows = payload[g.key] || []
+    rows.slice(0, 120).forEach(r => {
+      const c = extractChapter(r)
+      if (c > max) max = c
     })
+    return max
+  }, 0)
+  const domainStats = FULL_DATA_DOMAINS.filter(d => d.id !== 'overview').map(d => {
+    const ds = FULL_DATA_GROUPS.filter(g => g.domain === d.id)
+    const rowCount = ds.reduce((sum, g) => sum + (payload[g.key] || []).length, 0)
+    const filled = ds.filter(g => (payload[g.key] || []).length > 0).length
+    return { ...d, rowCount, filled, total: ds.length }
+  })
 
-    return (
-        <>
-            <div className="page-header section-page-header">
-                <h2>🧪 全量数据视图</h2>
-                <span className="card-badge badge-cyan">{FULL_DATA_GROUPS.length} 类数据源</span>
+  return (
+    <>
+      <div className="page-header section-page-header">
+        <h2>🧪 {t('dataView.title')}</h2>
+        <span className="card-badge badge-cyan">{FULL_DATA_GROUPS.length} {t('dataView.dataSources')}</span>
+      </div>
+
+      <div className="demo-summary-grid">
+        <div className="card stat-card">
+          <span className="stat-label">{t('dataView.totalRecords')}</span>
+          <span className="stat-value">{formatNumber(totalRows)}</span>
+          <span className="stat-sub">{t('dataView.totalRecordsSub')}</span>
+        </div>
+        <div className="card stat-card">
+          <span className="stat-label">{t('dataView.coveredSources')}</span>
+          <span className="stat-value plain">{nonEmptyGroups}/{FULL_DATA_GROUPS.length}</span>
+          <span className="stat-sub">{t('dataView.coveredSub')}</span>
+        </div>
+        <div className="card stat-card">
+          <span className="stat-label">{t('dataView.reachedCh')}</span>
+          <span className="stat-value plain">{maxChapter > 0 ? `${t('chapters.chPrefix')} ${maxChapter}` : '—'}</span>
+          <span className="stat-sub">{t('dataView.reachedSub')}</span>
+        </div>
+        <div className="card stat-card">
+          <span className="stat-label">{t('dataView.currentView')}</span>
+          <span className="stat-value plain">{FULL_DATA_DOMAINS.find(d => d.id === domain)?.labelKey ? t(d.labelKey) : '—'}</span>
+          <span className="stat-sub">{groups.length} {t('dataView.viewSub')}</span>
+        </div>
+      </div>
+
+      <div className="demo-domain-tabs">
+        {FULL_DATA_DOMAINS.map(item => (
+          <button
+            key={item.id}
+            className={`demo-domain-tab ${domain === item.id ? 'active' : ''}`}
+            onClick={() => setDomain(item.id)}
+          >
+            {t(item.labelKey)}
+          </button>
+        ))}
+      </div>
+
+      {domain === 'overview' ? (
+        <div className="demo-domain-grid">
+          {domainStats.map(ds => (
+            <div className="card" key={ds.id}>
+              <div className="card-header">
+                <span className="card-title">{t(ds.labelKey)}</span>
+                <span className="card-badge badge-purple">{ds.filled}/{ds.total}</span>
+              </div>
+              <div className="domain-stat-number">{formatNumber(ds.rowCount)}</div>
+              <div className="stat-sub">{t('dataView.totalRecordsSub')}</div>
             </div>
+          ))}
+        </div>
+      ) : null}
 
-            <div className="demo-summary-grid">
-                <div className="card stat-card">
-                    <span className="stat-label">总记录数</span>
-                    <span className="stat-value">{formatNumber(totalRows)}</span>
-                    <span className="stat-sub">当前返回的全部数据行</span>
-                </div>
-                <div className="card stat-card">
-                    <span className="stat-label">已覆盖数据源</span>
-                    <span className="stat-value plain">{nonEmptyGroups}/{FULL_DATA_GROUPS.length}</span>
-                    <span className="stat-sub">有数据的表 / 总表数</span>
-                </div>
-                <div className="card stat-card">
-                    <span className="stat-label">最新章节触达</span>
-                    <span className="stat-value plain">{maxChapter > 0 ? `第 ${maxChapter} 章` : '—'}</span>
-                    <span className="stat-sub">按可识别 chapter 字段估算</span>
-                </div>
-                <div className="card stat-card">
-                    <span className="stat-label">当前视图</span>
-                    <span className="stat-value plain">{FULL_DATA_DOMAINS.find(d => d.id === domain)?.label}</span>
-                    <span className="stat-sub">{groups.length} 个数据分组</span>
-                </div>
+      {groups.map(g => {
+        const count = (payload[g.key] || []).length
+        return (
+          <div className="card demo-group-card" key={g.key}>
+            <div className="card-header">
+              <span className="card-title">{t(g.titleKey)}</span>
+              <span className={`card-badge ${count > 0 ? 'badge-blue' : 'badge-amber'}`}>{count} {t('pagination.unit')}</span>
             </div>
-
-            <div className="demo-domain-tabs">
-                {FULL_DATA_DOMAINS.map(item => (
-                    <button
-                        key={item.id}
-                        className={`demo-domain-tab ${domain === item.id ? 'active' : ''}`}
-                        onClick={() => setDomain(item.id)}
-                    >
-                        {item.label}
-                    </button>
-                ))}
-            </div>
-
-            {domain === 'overview' ? (
-                <div className="demo-domain-grid">
-                    {domainStats.map(ds => (
-                        <div className="card" key={ds.id}>
-                            <div className="card-header">
-                                <span className="card-title">{ds.label}</span>
-                                <span className="card-badge badge-purple">{ds.filled}/{ds.total}</span>
-                            </div>
-                            <div className="domain-stat-number">{formatNumber(ds.rowCount)}</div>
-                            <div className="stat-sub">该数据域总记录数</div>
-                        </div>
-                    ))}
-                </div>
-            ) : null}
-
-            {groups.map(g => {
-                const count = (payload[g.key] || []).length
-                return (
-                    <div className="card demo-group-card" key={g.key}>
-                        <div className="card-header">
-                            <span className="card-title">{g.title}</span>
-                            <span className={`card-badge ${count > 0 ? 'badge-blue' : 'badge-amber'}`}>{count} 条</span>
-                        </div>
-                        <MiniTable
-                            rows={payload[g.key] || []}
-                            columns={g.columns}
-                            pageSize={12}
-                        />
-                    </div>
-                )
-            })}
-        </>
-    )
+            <MiniTable
+              rows={payload[g.key] || []}
+              columns={g.columns}
+              pageSize={12}
+            />
+          </div>
+        )
+      })}
+    </>
+  )
 }
 
 function MiniTable({ rows, columns, pageSize = 12 }) {
-    const [page, setPage] = useState(1)
+  const { t } = useI18n()
+  const [page, setPage] = useState(1)
 
-    useEffect(() => {
-        setPage(1)
-    }, [rows, columns, pageSize])
+  useEffect(() => {
+    setPage(1)
+  }, [rows, columns, pageSize])
 
-    if (!rows || rows.length === 0) {
-        return <div className="empty-state compact"><p>暂无数据</p></div>
-    }
+  if (!rows || rows.length === 0) {
+    return <div className="empty-state compact"><p>{t('pagination.noData')}</p></div>
+  }
 
-    const totalPages = Math.max(1, Math.ceil(rows.length / pageSize))
-    const safePage = Math.min(page, totalPages)
-    const start = (safePage - 1) * pageSize
-    const list = rows.slice(start, start + pageSize)
+  const totalPages = Math.max(1, Math.ceil(rows.length / pageSize))
+  const safePage = Math.min(page, totalPages)
+  const start = (safePage - 1) * pageSize
+  const list = rows.slice(start, start + pageSize)
 
-    return (
-        <>
-            <div className="table-wrap">
-                <table className="data-table">
-                    <thead>
-                        <tr>{columns.map(c => <th key={c}>{c}</th>)}</tr>
-                    </thead>
-                    <tbody>
-                        {list.map((row, i) => (
-                            <tr key={i}>
-                                {columns.map(c => (
-                                    <td key={c} className="truncate" style={{ maxWidth: 240 }}>
-                                        {formatCell(row?.[c])}
-                                    </td>
-                                ))}
-                            </tr>
-                        ))}
-                    </tbody>
-                </table>
-            </div>
-            <div className="table-pagination">
-                <button
-                    className="page-btn"
-                    type="button"
-                    onClick={() => setPage(p => Math.max(1, p - 1))}
-                    disabled={safePage <= 1}
-                >
-                    上一页
-                </button>
-                <span className="page-info">
-                    第 {safePage} / {totalPages} 页 · 共 {rows.length} 条
-                </span>
-                <button
-                    className="page-btn"
-                    type="button"
-                    onClick={() => setPage(p => Math.min(totalPages, p + 1))}
-                    disabled={safePage >= totalPages}
-                >
-                    下一页
-                </button>
-            </div>
-        </>
-    )
+  return (
+    <>
+      <div className="table-wrap">
+        <table className="data-table">
+          <thead>
+            <tr>{columns.map(c => <th key={c}>{c}</th>)}</tr>
+          </thead>
+          <tbody>
+            {list.map((row, i) => (
+              <tr key={i}>
+                {columns.map(c => (
+                  <td key={c} className="truncate" style={{ maxWidth: 240 }}>
+                    {formatCell(row?.[c])}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="table-pagination">
+        <button
+          className="page-btn"
+          type="button"
+          onClick={() => setPage(p => Math.max(1, p - 1))}
+          disabled={safePage <= 1}
+        >
+          {t('pagination.prev')}
+        </button>
+        <span className="page-info">
+          {t('pagination.page')} {safePage} / {totalPages} {t('pagination.of')} · {t('pagination.total')} {rows.length} {t('pagination.items')}
+        </span>
+        <button
+          className="page-btn"
+          type="button"
+          onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+          disabled={safePage >= totalPages}
+        >
+          {t('pagination.next')}
+        </button>
+      </div>
+    </>
+  )
 }
 
 function extractChapter(row) {
-    if (!row || typeof row !== 'object') return 0
-    const candidates = [
-        row.chapter,
-        row.start_chapter,
-        row.end_chapter,
-        row.chapter_discovered,
-        row.first_appearance,
-        row.last_appearance,
-    ]
-    for (const c of candidates) {
-        const n = Number(c)
-        if (Number.isFinite(n) && n > 0) return n
-    }
-    return 0
+  if (!row || typeof row !== 'object') return 0
+  const candidates = [
+    row.chapter,
+    row.start_chapter,
+    row.end_chapter,
+    row.chapter_discovered,
+    row.first_appearance,
+    row.last_appearance,
+  ]
+  for (const c of candidates) {
+    const n = Number(c)
+    if (Number.isFinite(n) && n > 0) return n
+  }
+  return 0
 }
 
 
 // ====================================================================
-// 子组件：文件树递归
+// Sub-component: File tree recursion
 // ====================================================================
 
 function TreeNodes({ items, selected, onSelect, depth = 0 }) {
-    const [expanded, setExpanded] = useState({})
-    if (!items || items.length === 0) return null
+  const [expanded, setExpanded] = useState({})
+  if (!items || items.length === 0) return null
 
-    return items.map((item, i) => {
-        const key = item.path || `${depth}-${i}`
-        if (item.type === 'dir') {
-            const isOpen = expanded[key]
-            return (
-                <li key={key}>
-                    <div
-                        className="tree-item"
-                        role="button"
-                        tabIndex={0}
-                        onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && (e.preventDefault(), setExpanded(prev => ({ ...prev, [key]: !prev[key] })))}
-                        onClick={() => setExpanded(prev => ({ ...prev, [key]: !prev[key] }))}
-                    >
-                        <span className="tree-icon">{isOpen ? '📂' : '📁'}</span>
-                        <span>{item.name}</span>
-                    </div>
-                    {isOpen && item.children && (
-                        <ul className="tree-children">
-                            <TreeNodes items={item.children} selected={selected} onSelect={onSelect} depth={depth + 1} />
-                        </ul>
-                    )}
-                </li>
-            )
-        }
-        return (
-            <li key={key}>
-                <div
-                    className={`tree-item ${selected === item.path ? 'active' : ''}`}
-                    role="button"
-                    tabIndex={0}
-                    onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && (e.preventDefault(), onSelect(item.path))}
-                    onClick={() => onSelect(item.path)}
-                >
-                    <span className="tree-icon">📄</span>
-                    <span>{item.name}</span>
-                </div>
-            </li>
-        )
-    })
+  return items.map((item, i) => {
+    const key = item.path || `${depth}-${i}`
+    if (item.type === 'dir') {
+      const isOpen = expanded[key]
+      return (
+        <li key={key}>
+          <div
+            className="tree-item"
+            role="button"
+            tabIndex={0}
+            onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && (e.preventDefault(), setExpanded(prev => ({ ...prev, [key]: !prev[key] })))}
+            onClick={() => setExpanded(prev => ({ ...prev, [key]: !prev[key] }))}
+          >
+            <span className="tree-icon">{isOpen ? '📂' : '📁'}</span>
+            <span>{item.name}</span>
+          </div>
+          {isOpen && item.children && (
+            <ul className="tree-children">
+              <TreeNodes items={item.children} selected={selected} onSelect={onSelect} depth={depth + 1} />
+            </ul>
+          )}
+        </li>
+      )
+    }
+    return (
+      <li key={key}>
+        <div
+          className={`tree-item ${selected === item.path ? 'active' : ''}`}
+          role="button"
+          tabIndex={0}
+          onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && (e.preventDefault(), onSelect(item.path))}
+          onClick={() => onSelect(item.path)}
+        >
+          <span className="tree-icon">📄</span>
+          <span>{item.name}</span>
+        </div>
+      </li>
+    )
+  })
 }
 
 
 // ====================================================================
-// 辅助：数字格式化
+// Helpers: Number formatting
 // ====================================================================
 
 function formatNumber(n) {
-    if (n >= 10000) return new Intl.NumberFormat('zh-CN', { maximumFractionDigits: 1 }).format(n / 10000) + ' 万'
-    return new Intl.NumberFormat('zh-CN').format(n)
+  if (n >= 10000) return new Intl.NumberFormat('zh-CN', { maximumFractionDigits: 1 }).format(n / 10000) + ' 万'
+  return new Intl.NumberFormat('zh-CN').format(n)
 }
 
 function formatJSON(str) {
-    try {
-        return JSON.stringify(JSON.parse(str), null, 2)
-    } catch {
-        return str
-    }
+  try {
+    return JSON.stringify(JSON.parse(str), null, 2)
+  } catch {
+    return str
+  }
 }
 
 function formatCell(v) {
-    if (v === null || v === undefined) return '—'
-    if (typeof v === 'boolean') return v ? 'true' : 'false'
-    if (typeof v === 'object') {
-        try {
-            return JSON.stringify(v)
-        } catch {
-            return String(v)
-        }
+  if (v === null || v === undefined) return '—'
+  if (typeof v === 'boolean') return v ? 'true' : 'false'
+  if (typeof v === 'object') {
+    try {
+      return JSON.stringify(v)
+    } catch {
+      return String(v)
     }
-    const s = String(v)
-    return s.length > 180 ? `${s.slice(0, 180)}...` : s
+  }
+  const s = String(v)
+  return s.length > 180 ? `${s.slice(0, 180)}...` : s
 }

--- a/webnovel-writer/dashboard/frontend/src/i18n.jsx
+++ b/webnovel-writer/dashboard/frontend/src/i18n.jsx
@@ -1,0 +1,192 @@
+import { createContext, useContext, useState, useCallback } from 'react'
+
+const STORAGE_KEY = 'webnovel_dashboard_locale'
+
+const DEFAULT_LOCALE = 'zh-CN'
+
+export const LOCALES = [
+  { code: 'zh-CN', label: '中文' },
+  { code: 'vi', label: 'Tiếng Việt' },
+  { code: 'en', label: 'English' },
+]
+
+// ====================================================================
+// Dictionary: zh-CN / vi / en
+// ====================================================================
+const dict = {
+  'zh-CN': {
+    nav: { dashboard: '数据总览', entities: '设定词典', graph: '关系图谱', chapters: '章节一览', files: '文档浏览', reading: '追读力' },
+    live: { connected: '实时同步中', disconnected: '未连接' },
+    loading: '加载中…',
+    dashboard: {
+      title: '数据总览', genre: '未知题材', totalWords: '总字数', target: '目标', chars: '字',
+      currentChapter: '当前章节', vol: '卷', protagonist: '主角状态', unknownRealm: '未知境界', notSet: '未设定',
+      unresolvedForeshadow: '未回收伏笔', totalForeshadow: '总计', foreshadowUnit: '条伏笔',
+      pendingForeshadow: '待回收伏笔 (Top 20)', content: '内容', status: '状态', plantedCh: '埋设章',
+      strandTitle: 'Strand Weave 节奏分布',
+    },
+    entities: {
+      title: '设定词典', all: '全部', name: '名称', type: '类型', tier: '层级',
+      first: '首现', last: '末现', units: '个实体', currentStatus: '当前状态',
+      historyTitle: '状态变化历史', chapter: '章', field: '字段', change: '变化',
+    },
+    graph: { title: '关系图谱', links: '条引力链接' },
+    chapters: {
+      title: '章节一览', chapter: '章节', chPrefix: '第', titleCol: '标题',
+      wordCount: '字数', location: '地点', characters: '角色', noChapters: '暂无章节数据',
+    },
+    files: {
+      title: '文档浏览', selectFile: '选择左侧文件以预览内容',
+      readFailed: '[读取失败]', binaryPreview: '[二进制文件，无法预览]',
+    },
+    reading: {
+      title: '追读力分析', chapterCol: '章节', hookType: '钩子类型', hookStrength: '钩子强度',
+      transition: '过渡章', override: 'Override', debtBalance: '债务余额',
+      noData: '暂无追读力数据', chapterData: '章数据',
+    },
+    dataView: {
+      title: '全量数据视图', dataSources: '类数据源', totalRecords: '总记录数',
+      totalRecordsSub: '当前返回的全部数据行', coveredSources: '已覆盖数据源',
+      coveredSub: '有数据的表 / 总表数', reachedCh: '最新章节触达',
+      reachedSub: '按可识别 chapter 字段估算', currentView: '当前视图', viewSub: '个数据分组',
+    },
+    domains: { overview: '总览', core: '基础档案', network: '关系与剧情', quality: '质量审查', ops: 'RAG 与工具' },
+    groups: {
+      entities: '实体', chapters: '章节', scenes: '场景', aliases: '别名',
+      stateChanges: '状态变化', relationships: '关系', relationshipEvents: '关系事件',
+      readingPower: '追读力', overrides: 'Override 合约', debts: '追读债务',
+      debtEvents: '债务事件', reviewMetrics: '审查指标', invalidFacts: '无效事实',
+      checklistScores: '写作清单评分', ragQueries: 'RAG 查询日志', toolStats: '工具调用统计',
+    },
+    pagination: { prev: '上一页', next: '下一页', page: '第', of: '页', total: '共', items: '条', noData: '暂无数据', unit: '条' },
+    entityDetail: { typeLabel: '类型', idLabel: 'ID', descLabel: '描述', currentLabel: '当前状态' },
+    filesTree: { folder: '目录' },
+  },
+  'vi': {
+    nav: { dashboard: 'Tổng Quan Dữ Liệu', entities: 'Từ Điển Thiết Lập', graph: 'Sơ Đồ Quan Hệ', chapters: 'Danh Sách Chương', files: 'Duyệt Tài Liệu', reading: 'Lực Theo Dõi' },
+    live: { connected: 'Đồng bộ thời gian thực', disconnected: 'Mất kết nối' },
+    loading: 'Đang tải…',
+    dashboard: {
+      title: 'Tổng Quan Dữ Liệu', genre: 'Thể loại chưa xác định', totalWords: 'Tổng số từ', target: 'Mục tiêu', chars: 'từ',
+      currentChapter: 'Chương hiện tại', vol: 'Quyển', protagonist: 'Trạng thái nhân vật chính', unknownRealm: 'Cảnh giới chưa biết', notSet: 'Chưa thiết lập',
+      unresolvedForeshadow: '伏笔 chưa thu hồi', totalForeshadow: 'Tổng cộng', foreshadowUnit: '伏笔',
+      pendingForeshadow: '伏笔 chờ thu hồi (Top 20)', content: 'Nội dung', status: 'Trạng thái', plantedCh: 'Chương chôn',
+      strandTitle: 'Phân bố nhịp Strand Weave',
+    },
+    entities: {
+      title: 'Từ Điển Thiết Lập', all: 'Tất cả', name: 'Tên', type: 'Loại', tier: 'Cấp bậc',
+      first: 'Xuất hiện đầu', last: 'Xuất hiện cuối', units: 'thực thể', currentStatus: 'Trạng thái hiện tại',
+      historyTitle: 'Lịch sử thay đổi trạng thái', chapter: 'Chương', field: 'Trường', change: 'Thay đổi',
+    },
+    graph: { title: 'Sơ Đồ Quan Hệ', links: 'liên kết lực hấp dẫn' },
+    chapters: {
+      title: 'Danh Sách Chương', chapter: 'Chương', chPrefix: 'Chương', titleCol: 'Tiêu đề',
+      wordCount: 'Số từ', location: 'Địa điểm', characters: 'Nhân vật', noChapters: 'Chưa có dữ liệu chương',
+    },
+    files: {
+      title: 'Duyệt Tài Liệu', selectFile: 'Chọn tệp bên trái để xem trước',
+      readFailed: '[Đọc thất bại]', binaryPreview: '[Tệp nhị phân, không thể xem trước]',
+    },
+    reading: {
+      title: 'Phân Tích Lực Theo Dõi', chapterCol: 'Chương', hookType: 'Loại móc', hookStrength: 'Độ mạnh móc',
+      transition: 'Chương chuyển tiếp', override: 'Override', debtBalance: 'Dư nợ',
+      noData: 'Chưa có dữ liệu lực theo dõi', chapterData: 'chương dữ liệu',
+    },
+    dataView: {
+      title: 'Chế Độ Xem Dữ Liệu Đầy Đủ', dataSources: 'loại nguồn dữ liệu', totalRecords: 'Tổng số bản ghi',
+      totalRecordsSub: 'Tổng hàng dữ liệu trả về hiện tại', coveredSources: 'Nguồn dữ liệu đã phủ',
+      coveredSub: 'Bảng có dữ liệu / Tổng số bảng', reachedCh: 'Chương mới nhất đạt',
+      reachedSub: 'Ước tính theo trường chapter có thể nhận dạng', currentView: 'Chế độ xem hiện tại', viewSub: 'nhóm dữ liệu',
+    },
+    domains: { overview: 'Tổng quan', core: 'Hồ sơ cơ bản', network: 'Quan hệ & Cốt truyện', quality: 'Kiểm tra chất lượng', ops: 'RAG & Công cụ' },
+    groups: {
+      entities: 'Thực thể', chapters: 'Chương', scenes: 'Cảnh', aliases: 'Biệt danh',
+      stateChanges: 'Thay đổi trạng thái', relationships: 'Quan hệ', relationshipEvents: 'Sự kiện quan hệ',
+      readingPower: 'Lực theo dõi', overrides: 'Hợp đồng Override', debts: 'Nợ theo dõi',
+      debtEvents: 'Sự kiện nợ', reviewMetrics: 'Chỉ số kiểm tra', invalidFacts: 'Sự kiện không hợp lệ',
+      checklistScores: 'Điểm danh sách kiểm tra viết', ragQueries: 'Nhật ký RAG', toolStats: 'Thống kê gọi công cụ',
+    },
+    pagination: { prev: 'Trước', next: 'Sau', page: 'Trang', of: '/', total: 'Tổng', items: 'bản ghi', noData: 'Chưa có dữ liệu', unit: 'bản ghi' },
+    entityDetail: { typeLabel: 'Loại', idLabel: 'ID', descLabel: 'Mô tả', currentLabel: 'Trạng thái hiện tại' },
+    filesTree: { folder: 'Thư mục' },
+  },
+  'en': {
+    nav: { dashboard: 'Dashboard', entities: 'Entities', graph: 'Relationship Graph', chapters: 'Chapters', files: 'Files', reading: 'Reading Power' },
+    live: { connected: 'Live Sync', disconnected: 'Disconnected' },
+    loading: 'Loading…',
+    dashboard: {
+      title: 'Dashboard', genre: 'Unknown genre', totalWords: 'Total Words', target: 'Target', chars: 'words',
+      currentChapter: 'Current Chapter', vol: 'Vol', protagonist: 'Protagonist', unknownRealm: 'Unknown realm', notSet: 'Not set',
+      unresolvedForeshadow: 'Unresolved Foreshadowing', totalForeshadow: 'Total', foreshadowUnit: 'items',
+      pendingForeshadow: 'Pending Foreshadow (Top 20)', content: 'Content', status: 'Status', plantedCh: 'Planted Ch.',
+      strandTitle: 'Strand Weave Distribution',
+    },
+    entities: {
+      title: 'Entities', all: 'All', name: 'Name', type: 'Type', tier: 'Tier',
+      first: 'First', last: 'Last', units: 'entities', currentStatus: 'Current Status',
+      historyTitle: 'State Change History', chapter: 'Ch.', field: 'Field', change: 'Change',
+    },
+    graph: { title: 'Relationship Graph', links: 'gravity links' },
+    chapters: {
+      title: 'Chapters', chapter: 'Chapter', chPrefix: 'Ch.', titleCol: 'Title',
+      wordCount: 'Word Count', location: 'Location', characters: 'Characters', noChapters: 'No chapter data yet',
+    },
+    files: {
+      title: 'Files', selectFile: 'Select a file from the left to preview',
+      readFailed: '[Read failed]', binaryPreview: '[Binary file, cannot preview]',
+    },
+    reading: {
+      title: 'Reading Power Analysis', chapterCol: 'Chapter', hookType: 'Hook Type', hookStrength: 'Hook Strength',
+      transition: 'Transition', override: 'Override', debtBalance: 'Debt Balance',
+      noData: 'No reading power data yet', chapterData: 'chapters of data',
+    },
+    dataView: {
+      title: 'Full Data View', dataSources: 'data sources', totalRecords: 'Total Records',
+      totalRecordsSub: 'Total rows returned', coveredSources: 'Covered Sources',
+      coveredSub: 'Tables with data / Total tables', reachedCh: 'Latest Chapter Reached',
+      reachedSub: 'Estimated by identifiable chapter fields', currentView: 'Current View', viewSub: 'data groups',
+    },
+    domains: { overview: 'Overview', core: 'Core', network: 'Network & Plot', quality: 'Quality Review', ops: 'RAG & Tools' },
+    groups: {
+      entities: 'Entities', chapters: 'Chapters', scenes: 'Scenes', aliases: 'Aliases',
+      stateChanges: 'State Changes', relationships: 'Relationships', relationshipEvents: 'Relationship Events',
+      readingPower: 'Reading Power', overrides: 'Override Contracts', debts: 'Chase Debts',
+      debtEvents: 'Debt Events', reviewMetrics: 'Review Metrics', invalidFacts: 'Invalid Facts',
+      checklistScores: 'Writing Checklist Scores', ragQueries: 'RAG Query Log', toolStats: 'Tool Call Stats',
+    },
+    pagination: { prev: 'Previous', next: 'Next', page: 'Page', of: 'of', total: 'Total', items: 'items', noData: 'No data', unit: 'rows' },
+    entityDetail: { typeLabel: 'Type', idLabel: 'ID', descLabel: 'Description', currentLabel: 'Current Status' },
+    filesTree: { folder: 'Folder' },
+  },
+}
+
+// ====================================================================
+// Helper: deep get by dot-path
+// ====================================================================
+function t(locale, path) {
+  const lang = dict[locale] || dict[DEFAULT_LOCALE]
+  return path.split('.').reduce((o, k) => o?.[k], lang) ?? path
+}
+
+const I18nContext = createContext(null)
+
+export function I18nProvider({ children }) {
+  const [locale, setLocaleRaw] = useState(() => {
+    try { return localStorage.getItem(STORAGE_KEY) || DEFAULT_LOCALE } catch { return DEFAULT_LOCALE }
+  })
+
+  const setLocale = useCallback((l) => {
+    setLocaleRaw(l)
+    try { localStorage.setItem(STORAGE_KEY, l) } catch {}
+  }, [])
+
+  const value = { locale, setLocale, t: (path) => t(locale, path) }
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>
+}
+
+export function useI18n() {
+  const ctx = useContext(I18nContext)
+  if (!ctx) throw new Error('useI18n must be used within I18nProvider')
+  return ctx
+}

--- a/webnovel-writer/dashboard/frontend/src/index.css
+++ b/webnovel-writer/dashboard/frontend/src/index.css
@@ -706,6 +706,42 @@ body {
   }
 }
 
+.lang-switcher {
+  border-top: 3px solid var(--border-main);
+  padding: 8px 10px;
+  display: flex;
+  gap: 4px;
+  justify-content: center;
+}
+
+.lang-btn {
+  border: 2px solid var(--border-main);
+  background: #fff9e8;
+  color: var(--text-main);
+  font-family: var(--font-body);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 4px 8px;
+  cursor: pointer;
+  box-shadow: var(--shadow-soft);
+  transition: transform 0.08s ease;
+}
+
+.lang-btn:hover {
+  transform: translate(-1px, -1px);
+}
+
+.lang-btn.active {
+  background: #dff3ff;
+  border-color: var(--accent-blue);
+}
+
+@media (max-width: 960px) {
+  .lang-switcher {
+    display: none;
+  }
+}
+
 @media (max-width: 720px) {
   .page-header h2 {
     font-size: 18px;


### PR DESCRIPTION
## Summary

This PR adds **multi-language support** (Vietnamese & English) to the Webnovel Writer dashboard, along with translated README files for international users.

### Changes
- **New i18n system** (`dashboard/frontend/src/i18n.jsx`): Complete internationalization framework using React Context API with localStorage persistence
- **Language switcher**: Sidebar button to toggle between zh-CN, vi (Vietnamese), and en (English) — instantly switches all UI text
- **Translated UI strings**: ~80+ strings across all 6 dashboard pages (Dashboard, Entities, Graph, Chapters, Files, Reading Power)
- **README_vi.md**: Full Vietnamese README with all sections translated
- **README_en.md**: Full English README with all sections translated

### How to test
1. Install the plugin and run `/webnovel-dashboard`
2. Locate the language switcher in the sidebar (bottom)
3. Click zh-CN / vi / en to switch languages
4. All page titles, navigation labels, stat cards, table headers, and section titles should update instantly

### Design decisions
- Dot-path translation key system (e.g., `t("nav.dashboard")`)
- Locale persisted in localStorage so user preference survives page reloads
- Switcher hidden on mobile (max-width 960px) to save sidebar space
- Chinese strings remain unchanged as the default locale