### PR TITLE
feat: hooks 增加 macOS/Linux 适配

### DIFF
--- a/webnovel-writer/hooks/hooks.json
+++ b/webnovel-writer/hooks/hooks.json
@@ -7,6 +7,11 @@
         "hooks": [
           {
             "type": "command",
+            "shell": "bash",
+            "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/log-hook-event.sh\""
+          },
+          {
+            "type": "command",
             "shell": "powershell",
             "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
           }
@@ -19,6 +24,11 @@
         "hooks": [
           {
             "type": "command",
+            "shell": "bash",
+            "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/log-hook-event.sh\""
+          },
+          {
+            "type": "command",
             "shell": "powershell",
             "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
           }
@@ -28,6 +38,11 @@
     "UserPromptSubmit": [
       {
         "hooks": [
+          {
+            "type": "command",
+            "shell": "bash",
+            "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/log-hook-event.sh\""
+          },
           {
             "type": "command",
             "shell": "powershell",
@@ -42,6 +57,11 @@
         "hooks": [
           {
             "type": "command",
+            "shell": "bash",
+            "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/log-hook-event.sh\""
+          },
+          {
+            "type": "command",
             "shell": "powershell",
             "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
           }
@@ -52,6 +72,11 @@
       {
         "matcher": "*",
         "hooks": [
+          {
+            "type": "command",
+            "shell": "bash",
+            "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/log-hook-event.sh\""
+          },
           {
             "type": "command",
             "shell": "powershell",
@@ -66,6 +91,11 @@
         "hooks": [
           {
             "type": "command",
+            "shell": "bash",
+            "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/log-hook-event.sh\""
+          },
+          {
+            "type": "command",
             "shell": "powershell",
             "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
           }
@@ -76,6 +106,11 @@
       {
         "matcher": "*",
         "hooks": [
+          {
+            "type": "command",
+            "shell": "bash",
+            "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/log-hook-event.sh\""
+          },
           {
             "type": "command",
             "shell": "powershell",
@@ -90,6 +125,11 @@
         "hooks": [
           {
             "type": "command",
+            "shell": "bash",
+            "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/log-hook-event.sh\""
+          },
+          {
+            "type": "command",
             "shell": "powershell",
             "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
           }
@@ -100,6 +140,11 @@
       {
         "matcher": "*",
         "hooks": [
+          {
+            "type": "command",
+            "shell": "bash",
+            "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/log-hook-event.sh\""
+          },
           {
             "type": "command",
             "shell": "powershell",
@@ -114,6 +159,11 @@
         "hooks": [
           {
             "type": "command",
+            "shell": "bash",
+            "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/log-hook-event.sh\""
+          },
+          {
+            "type": "command",
             "shell": "powershell",
             "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
           }
@@ -125,6 +175,11 @@
         "hooks": [
           {
             "type": "command",
+            "shell": "bash",
+            "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/log-hook-event.sh\""
+          },
+          {
+            "type": "command",
             "shell": "powershell",
             "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
           }
@@ -134,6 +189,11 @@
     "TaskCompleted": [
       {
         "hooks": [
+          {
+            "type": "command",
+            "shell": "bash",
+            "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/log-hook-event.sh\""
+          },
           {
             "type": "command",
             "shell": "powershell",
@@ -148,6 +208,11 @@
         "hooks": [
           {
             "type": "command",
+            "shell": "bash",
+            "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/log-hook-event.sh\""
+          },
+          {
+            "type": "command",
             "shell": "powershell",
             "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
           }
@@ -160,6 +225,11 @@
         "hooks": [
           {
             "type": "command",
+            "shell": "bash",
+            "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/log-hook-event.sh\""
+          },
+          {
+            "type": "command",
             "shell": "powershell",
             "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
           }
@@ -170,6 +240,11 @@
       {
         "matcher": "*",
         "hooks": [
+          {
+            "type": "command",
+            "shell": "bash",
+            "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/log-hook-event.sh\""
+          },
           {
             "type": "command",
             "shell": "powershell",

--- a/webnovel-writer/hooks/log-hook-event.sh
+++ b/webnovel-writer/hooks/log-hook-event.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+raw=$(cat)
+if [ -z "${raw// /}" ]; then
+  exit 0
+fi
+
+plugin_data="${CLAUDE_PLUGIN_DATA:-}"
+if [ -z "$plugin_data" ]; then
+  plugin_root="${CLAUDE_PLUGIN_ROOT:-}"
+  if [ -z "$plugin_root" ]; then
+    exit 0
+  fi
+  plugin_data="$plugin_root/.tmp_plugin_data"
+fi
+
+log_dir="$plugin_data/logs"
+mkdir -p "$log_dir"
+
+event_name=$(echo "$raw" | jq -r '.hook_event_name // "unknown"')
+
+if [ "$event_name" = "unknown" ]; then
+  json=$(jq -n \
+    --arg at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg raw "$raw" \
+    '{observed_at: $at, event: "invalid_json", raw: $raw}')
+else
+  json=$(echo "$raw" | jq -c \
+    --arg at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg ev "$event_name" \
+    '{observed_at: $at, event: $ev, session_id: .session_id, cwd: .cwd, transcript_path: .transcript_path, payload: .}')
+fi
+
+echo "$json" >> "$log_dir/hook-events.jsonl"
+echo "$json" >> "$log_dir/$event_name.jsonl"


### PR DESCRIPTION
新增 log-hook-event.sh (bash) 与原有 log-hook-event.ps1 (PowerShell) 并存， hooks.json 中同时注册两种 shell，实现跨平台兼容。