### PR TITLE
feat: hooks 跨平台支持，新增 Python 分发器

### DIFF
--- a/webnovel-writer/hooks/dispatch.py
+++ b/webnovel-writer/hooks/dispatch.py
@@ -1,0 +1,58 @@
+import sys
+import os
+import json
+import subprocess
+from datetime import datetime, timezone
+
+raw = sys.stdin.read()
+if not raw.strip():
+    sys.exit(0)
+
+plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT", "")
+hooks_dir = os.path.join(plugin_root, "hooks")
+
+if sys.platform == "win32":
+    script = os.path.join(hooks_dir, "log-hook-event.ps1")
+    result = subprocess.run(
+        ["powershell", "-File", script],
+        input=raw,
+        text=True,
+    )
+    sys.exit(result.returncode)
+
+# macOS / Linux
+plugin_data = os.environ.get("CLAUDE_PLUGIN_DATA", "")
+if not plugin_data:
+    if not plugin_root:
+        sys.exit(0)
+    plugin_data = os.path.join(plugin_root, ".tmp_plugin_data")
+
+log_dir = os.path.join(plugin_data, "logs")
+os.makedirs(log_dir, exist_ok=True)
+
+try:
+    payload = json.loads(raw)
+    event_name = payload.get("hook_event_name") or "unknown"
+    record = {
+        "observed_at": datetime.now(timezone.utc).isoformat(),
+        "event": event_name,
+        "session_id": payload.get("session_id", ""),
+        "cwd": payload.get("cwd", ""),
+        "transcript_path": payload.get("transcript_path", ""),
+        "payload": payload,
+    }
+except json.JSONDecodeError:
+    event_name = "invalid_json"
+    record = {
+        "observed_at": datetime.now(timezone.utc).isoformat(),
+        "event": event_name,
+        "raw": raw,
+    }
+
+line = json.dumps(record, ensure_ascii=False)
+for path in [
+    os.path.join(log_dir, "hook-events.jsonl"),
+    os.path.join(log_dir, f"{event_name}.jsonl"),
+]:
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(line + "\n")

--- a/webnovel-writer/hooks/hooks.json
+++ b/webnovel-writer/hooks/hooks.json
@@ -7,8 +7,8 @@
         "hooks": [
           {
             "type": "command",
-            "shell": "powershell",
-            "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
+            "shell": "python3",
+            "command": "import os; exec(open(os.path.join(os.environ['CLAUDE_PLUGIN_ROOT'],'hooks','dispatch.py')).read())"
           }
         ]
       }
@@ -19,8 +19,8 @@
         "hooks": [
           {
             "type": "command",
-            "shell": "powershell",
-            "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
+            "shell": "python3",
+            "command": "import os; exec(open(os.path.join(os.environ['CLAUDE_PLUGIN_ROOT'],'hooks','dispatch.py')).read())"
           }
         ]
       }
@@ -30,8 +30,8 @@
         "hooks": [
           {
             "type": "command",
-            "shell": "powershell",
-            "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
+            "shell": "python3",
+            "command": "import os; exec(open(os.path.join(os.environ['CLAUDE_PLUGIN_ROOT'],'hooks','dispatch.py')).read())"
           }
         ]
       }
@@ -42,8 +42,8 @@
         "hooks": [
           {
             "type": "command",
-            "shell": "powershell",
-            "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
+            "shell": "python3",
+            "command": "import os; exec(open(os.path.join(os.environ['CLAUDE_PLUGIN_ROOT'],'hooks','dispatch.py')).read())"
           }
         ]
       }
@@ -54,8 +54,8 @@
         "hooks": [
           {
             "type": "command",
-            "shell": "powershell",
-            "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
+            "shell": "python3",
+            "command": "import os; exec(open(os.path.join(os.environ['CLAUDE_PLUGIN_ROOT'],'hooks','dispatch.py')).read())"
           }
         ]
       }
@@ -66,8 +66,8 @@
         "hooks": [
           {
             "type": "command",
-            "shell": "powershell",
-            "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
+            "shell": "python3",
+            "command": "import os; exec(open(os.path.join(os.environ['CLAUDE_PLUGIN_ROOT'],'hooks','dispatch.py')).read())"
           }
         ]
       }
@@ -78,8 +78,8 @@
         "hooks": [
           {
             "type": "command",
-            "shell": "powershell",
-            "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
+            "shell": "python3",
+            "command": "import os; exec(open(os.path.join(os.environ['CLAUDE_PLUGIN_ROOT'],'hooks','dispatch.py')).read())"
           }
         ]
       }
@@ -90,8 +90,8 @@
         "hooks": [
           {
             "type": "command",
-            "shell": "powershell",
-            "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
+            "shell": "python3",
+            "command": "import os; exec(open(os.path.join(os.environ['CLAUDE_PLUGIN_ROOT'],'hooks','dispatch.py')).read())"
           }
         ]
       }
@@ -102,8 +102,8 @@
         "hooks": [
           {
             "type": "command",
-            "shell": "powershell",
-            "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
+            "shell": "python3",
+            "command": "import os; exec(open(os.path.join(os.environ['CLAUDE_PLUGIN_ROOT'],'hooks','dispatch.py')).read())"
           }
         ]
       }
@@ -114,8 +114,8 @@
         "hooks": [
           {
             "type": "command",
-            "shell": "powershell",
-            "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
+            "shell": "python3",
+            "command": "import os; exec(open(os.path.join(os.environ['CLAUDE_PLUGIN_ROOT'],'hooks','dispatch.py')).read())"
           }
         ]
       }
@@ -125,8 +125,8 @@
         "hooks": [
           {
             "type": "command",
-            "shell": "powershell",
-            "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
+            "shell": "python3",
+            "command": "import os; exec(open(os.path.join(os.environ['CLAUDE_PLUGIN_ROOT'],'hooks','dispatch.py')).read())"
           }
         ]
       }
@@ -136,8 +136,8 @@
         "hooks": [
           {
             "type": "command",
-            "shell": "powershell",
-            "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
+            "shell": "python3",
+            "command": "import os; exec(open(os.path.join(os.environ['CLAUDE_PLUGIN_ROOT'],'hooks','dispatch.py')).read())"
           }
         ]
       }
@@ -148,8 +148,8 @@
         "hooks": [
           {
             "type": "command",
-            "shell": "powershell",
-            "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
+            "shell": "python3",
+            "command": "import os; exec(open(os.path.join(os.environ['CLAUDE_PLUGIN_ROOT'],'hooks','dispatch.py')).read())"
           }
         ]
       }
@@ -160,8 +160,8 @@
         "hooks": [
           {
             "type": "command",
-            "shell": "powershell",
-            "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
+            "shell": "python3",
+            "command": "import os; exec(open(os.path.join(os.environ['CLAUDE_PLUGIN_ROOT'],'hooks','dispatch.py')).read())"
           }
         ]
       }
@@ -172,8 +172,8 @@
         "hooks": [
           {
             "type": "command",
-            "shell": "powershell",
-            "command": "& \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\log-hook-event.ps1\""
+            "shell": "python3",
+            "command": "import os; exec(open(os.path.join(os.environ['CLAUDE_PLUGIN_ROOT'],'hooks','dispatch.py')).read())"
           }
         ]
       }


### PR DESCRIPTION
- 新增 dispatch.py：Windows 上透传 stdin 调用 powershell 执行 .ps1， macOS/Linux 上用纯 Python 标准库实现日志记录
- hooks.json 全部改为 shell: "python3" 调用 dispatch.py
- log-hook-event.ps1 保持不变，Windows 上继续使用

不知道佬的后续安排，所以就增加了mac平台执行的py文件和修改hooks.json使用python。目前来说，没有报错了，py完全按照ps1逻辑转过来的。