### PR TITLE
fix: stop blocking direct edits to state.json (#113)

### DIFF
--- a/webnovel-writer/hooks/guard_runtime_write.py
+++ b/webnovel-writer/hooks/guard_runtime_write.py
@@ -11,9 +11,11 @@ from typing import Any
 
 
 DISABLE_ENV = "WEBNOVEL_DISABLE_RUNTIME_GUARD_HOOK"
+# state.json is intentionally NOT protected: audits routinely require bulk
+# fixes that update_state.py flags cannot express, and state.json has its own
+# backup + rebuild path (issue #113).
 PROTECTED_SUFFIXES = (
     ".story-system/commits/",
-    ".webnovel/state.json",
     ".webnovel/index.db",
     ".webnovel/vectors.db",
     ".webnovel/memory_scratchpad.json",

--- a/webnovel-writer/scripts/tests/test_hooks.py
+++ b/webnovel-writer/scripts/tests/test_hooks.py
@@ -47,11 +47,35 @@ def test_guard_blocks_direct_commit_file_write():
     assert "permissionDecision" in proc.stderr
 
 
-def test_guard_blocks_direct_state_write():
+def test_guard_allows_direct_state_write():
+    # issue #113: audit fixes need direct state.json edits; the guard no
+    # longer blocks them.
     proc = _run_guard(
         {
             "tool_name": "Edit",
             "tool_input": {"file_path": r"D:\book\.webnovel\state.json"},
+        }
+    )
+
+    assert proc.returncode == 0
+
+
+def test_guard_allows_bash_state_write():
+    proc = _run_guard(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": 'python fix_state.py > "D:/book/.webnovel/state.json"'},
+        }
+    )
+
+    assert proc.returncode == 0
+
+
+def test_guard_still_blocks_index_db_write():
+    proc = _run_guard(
+        {
+            "tool_name": "Edit",
+            "tool_input": {"file_path": r"D:\book\.webnovel\index.db"},
         }
     )
 


### PR DESCRIPTION
## 问题

审核后经常产生几十条 state.json 修复，但 PreToolUse hook（`guard_runtime_write.py`）把 `.webnovel/state.json` 列入保护名单，AI 的 Edit/Write/Bash 直写全部被拒，用户只能手动逐条修改。

## 修复

- 将 `.webnovel/state.json` 从 `PROTECTED_SUFFIXES` 中移除：`update_state.py` 的命令行参数无法覆盖审核修复涉及的所有字段，而 state.json 自身已有备份与重建机制，放开直写是安全的。
- 事件存储与只读投影文件（`.story-system/commits/`、`index.db`、`vectors.db`、`projection_log.jsonl`、`memory_scratchpad.json`）仍保持保护。
- 测试同步更新：state.json 的 Edit 与 Bash 重定向写入改为允许，并新增用例确认 `index.db` 仍被阻止。`test_hooks.py` 8 项全部通过。

Fixes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)