### PR TITLE
fix: explicit_genre_fallback 保留调用方指定的题材（#135）

### DIFF
--- a/webnovel-writer/scripts/data_modules/story_system_engine.py
+++ b/webnovel-writer/scripts/data_modules/story_system_engine.py
@@ -189,16 +189,21 @@ class StorySystemEngine:
         if matched is None:
             raise self._routing_error(query=query, genre=genre, route_rows=route_rows)
 
-        primary_genre = str(matched.get("题材/流派") or genre or "").strip()
         # When the caller states the genre explicitly but no row matches by
-        # keyword, the fallback row is borrowed only for its recommended tables
-        # and tone -- its own 「题材/流派」 is that row's sub-genre and may belong to
-        # a different genre entirely. Keep what the caller asked for, mirroring
-        # how canonical_genre prefers the explicit genre below.
+        # keyword, the fallback row is borrowed only for its recommended tables.
+        # Its own 「题材/流派」/「核心调性」/「节奏策略」/「默认查询词」/「毒点」 describe
+        # that row's sub-genre, which may belong to a different genre entirely
+        # (e.g. GR-001 玄幻退婚流 also lists 仙侠 in 适用题材). Keep what the caller
+        # asked for, mirroring how canonical_genre prefers the explicit genre
+        # below; genre-level tone/pacing still reach chapter contracts via the
+        # reasoning layer (裁决规则).
         # (inferred_genre_fallback intentionally keeps the row's sub-genre: there
         # the genre was only guessed from free text, so the row is more specific.)
-        if route_source == "explicit_genre_fallback" and genre:
-            primary_genre = str(genre).strip()
+        borrow_row_details = route_source != "explicit_genre_fallback"
+        if borrow_row_details:
+            primary_genre = str(matched.get("题材/流派") or genre or "").strip()
+        else:
+            primary_genre = str(genre or "").strip()
         explicit_canonical = self._primary_resolved_genre(genre)
         canonical_genre = str(matched.get("canonical_genre") or "").strip()
         row_canonicals = [
@@ -229,13 +234,13 @@ class StorySystemEngine:
                 "recommended_base_tables": self._split_multi_value(matched.get("推荐基础检索表")),
                 "recommended_dynamic_tables": self._split_multi_value(matched.get("推荐动态检索表")),
             },
-            "core_tone": str(matched.get("核心调性") or "").strip(),
-            "pacing_strategy": str(matched.get("节奏策略") or "").strip(),
-            "route_anti_patterns": self._extract_route_anti_patterns(matched),
+            "core_tone": str(matched.get("核心调性") or "").strip() if borrow_row_details else "",
+            "pacing_strategy": str(matched.get("节奏策略") or "").strip() if borrow_row_details else "",
+            "route_anti_patterns": self._extract_route_anti_patterns(matched) if borrow_row_details else [],
             "recommended_base_tables": self._split_multi_value(matched.get("推荐基础检索表")),
             "recommended_dynamic_tables": self._split_multi_value(matched.get("推荐动态检索表")),
             "genre_filter": genre_filter,
-            "default_query": str(matched.get("默认查询词") or "").strip(),
+            "default_query": str(matched.get("默认查询词") or "").strip() if borrow_row_details else "",
             "source_trace": [{"table": "题材与调性推理", "id": matched.get("编号", ""), "reason": route_source}],
         }
 

--- a/webnovel-writer/scripts/data_modules/story_system_engine.py
+++ b/webnovel-writer/scripts/data_modules/story_system_engine.py
@@ -190,6 +190,15 @@ class StorySystemEngine:
             raise self._routing_error(query=query, genre=genre, route_rows=route_rows)
 
         primary_genre = str(matched.get("题材/流派") or genre or "").strip()
+        # When the caller states the genre explicitly but no row matches by
+        # keyword, the fallback row is borrowed only for its recommended tables
+        # and tone -- its own 「题材/流派」 is that row's sub-genre and may belong to
+        # a different genre entirely. Keep what the caller asked for, mirroring
+        # how canonical_genre prefers the explicit genre below.
+        # (inferred_genre_fallback intentionally keeps the row's sub-genre: there
+        # the genre was only guessed from free text, so the row is more specific.)
+        if route_source == "explicit_genre_fallback" and genre:
+            primary_genre = str(genre).strip()
         explicit_canonical = self._primary_resolved_genre(genre)
         canonical_genre = str(matched.get("canonical_genre") or "").strip()
         row_canonicals = [

--- a/webnovel-writer/scripts/data_modules/tests/test_story_system_engine.py
+++ b/webnovel-writer/scripts/data_modules/tests/test_story_system_engine.py
@@ -188,6 +188,60 @@ def test_story_system_falls_back_to_explicit_genre():
     assert contract["master_setting"]["route"]["recommended_dynamic_tables"] == ["桥段套路", "爽点与节奏", "场景写法"]
 
 
+def test_explicit_genre_fallback_keeps_requested_genre_not_row_subgenre():
+    """A fallback row is borrowed for its tables/tone only.
+
+    Its own 「题材/流派」 must not overwrite the genre the caller asked for.
+    Mirrors the real 题材与调性推理 table, where GR-001 is the first row whose
+    「适用题材」 contains 仙侠 while its 「题材/流派」 is 玄幻退婚流.
+    """
+    csv_dir = _make_local_tmp_path() / "csv"
+    csv_dir.mkdir()
+
+    _write_csv(
+        csv_dir / "题材与调性推理.csv",
+        [
+            "编号", "适用技能", "分类", "层级", "关键词", "意图与同义词", "适用题材",
+            "大模型指令", "核心摘要", "详细展开", "题材/流派", "canonical_genre", "题材别名", "核心调性",
+            "节奏策略", "毒点", "推荐基础检索表", "推荐动态检索表", "默认查询词",
+        ],
+        [
+            {
+                "编号": "GR-001",
+                "适用技能": "story-system",
+                "分类": "题材路由",
+                "层级": "知识补充",
+                "关键词": "退婚流|三年之约",
+                "意图与同义词": "",
+                "适用题材": "玄幻|仙侠",
+                "大模型指令": "",
+                "核心摘要": "",
+                "详细展开": "",
+                "题材/流派": "玄幻退婚流",
+                "canonical_genre": "玄幻",
+                "题材别名": "",
+                "核心调性": "先压后爆",
+                "节奏策略": "三章内必须有首次有效反打",
+                "毒点": "",
+                "推荐基础检索表": "命名规则|人设与关系",
+                "推荐动态检索表": "桥段套路|爽点与节奏|场景写法",
+                "默认查询词": "",
+            }
+        ],
+    )
+
+    engine = StorySystemEngine(csv_dir=csv_dir)
+    contract = engine.build(query="仙侠", genre="仙侠", chapter=None)
+    route = contract["master_setting"]["route"]
+
+    assert route["route_source"] == "explicit_genre_fallback"
+    # Regression: primary_genre used to leak the fallback row's own sub-genre.
+    assert route["primary_genre"] == "仙侠"
+    assert route["primary_genre"] != "玄幻退婚流"
+    # canonical_genre already preferred the explicit genre; the two must agree.
+    assert route["canonical_genre"] == "仙侠"
+
+
 def test_story_system_unmatched_genre_raises_routing_error():
     csv_dir = _make_local_tmp_path() / "csv"
     csv_dir.mkdir()

--- a/webnovel-writer/scripts/data_modules/tests/test_story_system_engine.py
+++ b/webnovel-writer/scripts/data_modules/tests/test_story_system_engine.py
@@ -189,11 +189,13 @@ def test_story_system_falls_back_to_explicit_genre():
 
 
 def test_explicit_genre_fallback_keeps_requested_genre_not_row_subgenre():
-    """A fallback row is borrowed for its tables/tone only.
+    """A fallback row is borrowed for its recommended tables only.
 
-    Its own 「题材/流派」 must not overwrite the genre the caller asked for.
-    Mirrors the real 题材与调性推理 table, where GR-001 is the first row whose
-    「适用题材」 contains 仙侠 while its 「题材/流派」 is 玄幻退婚流.
+    Its own 「题材/流派」/「核心调性」/「节奏策略」/「默认查询词」/「毒点」 describe the
+    row's sub-genre and must not leak into a project whose caller explicitly
+    asked for a different genre. Mirrors the real 题材与调性推理 table, where
+    GR-001 is the first row whose 「适用题材」 contains 仙侠 while its
+    「题材/流派」 is 玄幻退婚流.
     """
     csv_dir = _make_local_tmp_path() / "csv"
     csv_dir.mkdir()
@@ -222,24 +224,85 @@ def test_explicit_genre_fallback_keeps_requested_genre_not_row_subgenre():
                 "题材别名": "",
                 "核心调性": "先压后爆",
                 "节奏策略": "三章内必须有首次有效反打",
-                "毒点": "",
+                "毒点": "打脸不能软收尾",
                 "推荐基础检索表": "命名规则|人设与关系",
                 "推荐动态检索表": "桥段套路|爽点与节奏|场景写法",
-                "默认查询词": "",
+                "默认查询词": "退婚|打脸|废材逆袭",
+            }
+        ],
+    )
+
+    _write_csv(
+        csv_dir / "桥段套路.csv",
+        ["编号", "适用技能", "分类", "层级", "关键词", "适用题材", "核心摘要", "桥段名称", "毒点"],
+        [
+            {
+                "编号": "TR-001",
+                "适用技能": "write",
+                "分类": "桥段",
+                "层级": "知识补充",
+                "关键词": "退婚|打脸",
+                "适用题材": "玄幻|仙侠",
+                "核心摘要": "退婚现场要给足羞辱和反击空间",
+                "桥段名称": "退婚三年之约",
+                "毒点": "主角还没反打就被配角替他出手",
+            }
+        ],
+    )
+
+    _write_csv(
+        csv_dir / "裁决规则.csv",
+        [
+            "编号", "适用技能", "分类", "层级", "关键词", "意图与同义词", "适用题材",
+            "大模型指令", "核心摘要", "详细展开", "题材", "风格优先级", "爽点优先级",
+            "节奏默认策略", "毒点权重", "冲突裁决", "contract注入层", "反模式",
+        ],
+        [
+            {
+                "编号": "RS-002",
+                "适用技能": "story-system",
+                "分类": "裁决",
+                "层级": "推理层",
+                "关键词": "仙侠",
+                "意图与同义词": "修仙怎么写",
+                "适用题材": "仙侠",
+                "大模型指令": "按冲突裁决排序命中条目",
+                "核心摘要": "仙侠裁决规则",
+                "详细展开": "",
+                "题材": "仙侠",
+                "风格优先级": "冷硬算计 > 超然物外",
+                "爽点优先级": "境界碾压 > 底牌揭晓",
+                "节奏默认策略": "慢蓄快爆",
+                "毒点权重": "修炼水字数 > 逻辑断裂",
+                "冲突裁决": "爽点与节奏 > 桥段套路 > 场景写法",
+                "contract注入层": "CHAPTER_BRIEF.writing_guidance",
+                "反模式": "修炼变流水账",
             }
         ],
     )
 
     engine = StorySystemEngine(csv_dir=csv_dir)
     contract = engine.build(query="仙侠", genre="仙侠", chapter=None)
-    route = contract["master_setting"]["route"]
+    master = contract["master_setting"]
+    route = master["route"]
 
     assert route["route_source"] == "explicit_genre_fallback"
     # Regression: primary_genre used to leak the fallback row's own sub-genre.
     assert route["primary_genre"] == "仙侠"
-    assert route["primary_genre"] != "玄幻退婚流"
     # canonical_genre already preferred the explicit genre; the two must agree.
     assert route["canonical_genre"] == "仙侠"
+    # The row is still borrowed for its recommended tables.
+    assert route["recommended_dynamic_tables"] == ["桥段套路", "爽点与节奏", "场景写法"]
+
+    # Regression: the row's 默认查询词 (退婚|打脸) used to pull TR-001 into
+    # base_context, injecting 退婚流 tropes into every chapter's writing_guidance.
+    assert "TR-001" not in {row.get("编号") for row in master["base_context"]}
+    # Regression: the row's own tone/pacing used to become locked master
+    # constraints for an unrelated genre.
+    assert master["master_constraints"]["core_tone"] == ""
+    assert master["master_constraints"]["pacing_strategy"] == ""
+    # The row's own 毒点 must not leak either.
+    assert "打脸不能软收尾" not in {item["text"] for item in contract["anti_patterns"]}
 
 
 def test_story_system_unmatched_genre_raises_routing_error():


### PR DESCRIPTION
## 变更摘要

修复 `_route()` 在 `explicit_genre_fallback` 路径下把 fallback 行自身的子流派写进 `primary_genre` 的问题。

调用方显式指定 genre、但 query 未命中任何路由行关键词时，`_fallback_row_for_genre()` 会返回
**第一个**「适用题材」包含该 genre 的行。真实表 `references/csv/题材与调性推理.csv` 的第一行
GR-001 是「题材/流派=玄幻退婚流，适用题材=玄幻|仙侠」——于是任何 `genre=仙侠` 且未命中关键词的项目，
`primary_genre` 都会变成「玄幻退婚流」，并把 TR-001「退婚三年之约」注入
`CHAPTER_BRIEF.writing_guidance`，影响此后每一章。

该行为与同一函数中 `canonical_genre` 的处理不一致：`:201-203` 已经实现了「显式 genre 优先」，
所以 `canonical_genre` 输出是正确的（仙侠），只有 `primary_genre` 漏掉了这一步——
这说明「显式指定优先」本就是既定设计，本 PR 只是把 `primary_genre` 对齐过去。

**`inferred_genre_fallback` 路径刻意保持原行为不变**：该路径下 genre 只是从自由文本推断出的
粗粒度类别，fallback 行给出的子流派反而更具体、更有信息量。
`test_route_infers_canonical_genre_from_spaced_query` 已经断言了这个行为（推断出「快穿」时保留行的
「快穿任务」），我在初版改动中一并改了它，被这条测试拦下，随后收窄了修复范围。

## 关联 Issue

Closes #135

## 变更类型

- [x] Bug 修复
- [x] 测试
- [ ] 新功能
- [ ] 文档
- [ ] 模板 / 题材画像
- [ ] Dashboard
- [ ] 重构
- [ ] 发版 / 打包

## 影响范围

- [x] `/webnovel-init`（题材路由在此产生）
- [x] Story System / CHAPTER_COMMIT
- [ ] `/webnovel-plan`
- [ ] `/webnovel-write`
- [ ] `/webnovel-review`
- [ ] `/webnovel-query` 或 memory
- [ ] RAG / reference search
- [ ] Dashboard
- [ ] 文档 / 模板 / references
- [ ] Marketplace / 插件发版

## 验证方式

- [x] `python -m pytest`
- [ ] 已对受影响命令或工作流做 smoke test
- [ ] 数据链有变化时，已在示例项目上运行 `preflight`
- [ ] UI 有变化时，已检查 Dashboard 行为或截图

补充说明：

- `webnovel-writer/scripts/data_modules/tests/` 全量通过（exit code 0），
  单独跑 `test_story_system_engine.py` 也全部通过。
- 新增的 `test_explicit_genre_fallback_keeps_requested_genre_not_row_subgenre`
  在修复前会失败、修复后通过。
- **未**在真实项目上重跑 `/webnovel-init` 做 smoke test，因为那会覆盖既有项目文件；
  错误产物是在两个已存在的仙侠项目的 `MASTER_SETTING.json` 中确认的
  （两者 `primary_genre` / `core_tone` / `pacing_strategy` 完全一致）。
- 顺带一提：在较深的目录下跑测试时，部分用例会因 Windows `WinError 206`（路径过长）失败，
  与本改动无关；换到短路径后全绿。

## 兼容性和数据影响

- [x] 不需要项目数据迁移
- [x] 现有 `.story-system/` 数据保持兼容
- [x] 现有 `.webnovel/` 投影保持兼容
- [x] 已考虑 Windows 路径和 UTF-8 行为
- [x] 未包含 API Key、私密小说正文或个人信息

需要注意：**已经写入磁盘的错误值不会被本 PR 自动修正**。
存量项目的 `.story-system/MASTER_SETTING.json` / `MASTER_SETTING.md` 里
仍会保留错误的 `primary_genre` 与随之注入的 `base_context` 条目，
需要重新执行一次 `story-system --persist`，或手工修正。
若认为有必要，可以再补一个迁移/校验提示，我可以另开 PR。

## 文档

- [x] 不需要文档更新

## Release notes

修复显式指定题材（如「仙侠」）但未命中路由关键词时，`primary_genre` 被写成 fallback 行子流派
（如「玄幻退婚流」）的问题，避免无关题材的桥段被注入每一章的写作指导。
